### PR TITLE
 Fixes intermittent issues with Randomized parrot

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -270,7 +270,7 @@ func forgeConn() {
 
 	serverConn, clientConn := net.Pipe()
 
-	clientUtls.SetNetConn(clientConn)
+	clientUtls.SetUnderlyingConn(clientConn)
 
 	hs := clientUtls.HandshakeState
 	serverTls := tls.MakeConnWithCompleteHandshake(serverConn, hs.ServerHello.Vers, hs.ServerHello.CipherSuite,

--- a/u_conn.go
+++ b/u_conn.go
@@ -500,8 +500,8 @@ func (uconn *UConn) SetUnderlyingConn(c net.Conn) {
 	uconn.Conn.conn = c
 }
 
-func (uconn *UConn) SetNetConn(c net.Conn) {
-	uconn.Conn.conn = c
+func (uconn *UConn) GetUnderlyingConn() net.Conn {
+	return uconn.Conn.conn
 }
 
 // MakeConnWithCompleteHandshake allows to forge both server and client side TLS connections.

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -534,10 +534,11 @@ func (uconn *UConn) generateRandomizedSpec(WithALPN bool) (ClientHelloSpec, erro
 	if tossBiasedCoin(0.59) {
 		sigAndHashAlgos = append(sigAndHashAlgos, ECDSAWithP521AndSHA512)
 	}
-	if tossBiasedCoin(0.51) {
-		// these usually go together
+	if tossBiasedCoin(0.51) || p.TLSVersMax == VersionTLS13 {
+		// https://tools.ietf.org/html/rfc8446 says "...RSASSA-PSS (which is mandatory in TLS 1.3)..."
 		sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA256)
 		if tossBiasedCoin(0.9) {
+			// these usually go together
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA384)
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA512)
 		}
@@ -606,8 +607,11 @@ func (uconn *UConn) generateRandomizedSpec(WithALPN bool) (ClientHelloSpec, erro
 		ks := KeyShareExtension{[]KeyShare{
 			{Group: X25519}, // the key for the group will be generated later
 		}}
-		if tossBiasedCoin(0.5) {
-			ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
+		if tossBiasedCoin(0.25) {
+			// do not ADD second keyShare because crypto/tls does not support multiple ecdheParams
+			// TODO: add it back when they implement multiple keyShares, or implement it oursevles
+			// ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
+			ks.KeyShares[0].Group = CurveP256
 		}
 		pskExchangeModes := PSKKeyExchangeModesExtension{[]uint8{pskModeDHE}}
 		supportedVersionsExt := SupportedVersionsExtension{


### PR DESCRIPTION
As @AxbB36 reported, there were 2 types of issues with randomized parrot when tested against golang.org and ajax.aspnetcdn.com

1. Some servers would get upset if TLS 1.3 is being negotiated, but PSS signature algorithms are absent. Spec https://tools.ietf.org/html/rfc8446 seems to only briefly mention that it's mandatory in some way
```
   -  Implementations that advertise support for RSASSA-PSS (which is
      mandatory in TLS 1.3) MUST be prepared to accept a signature using
      that scheme even when TLS 1.2 is negotiated.  In TLS 1.2,
      RSASSA-PSS is used with RSA cipher suites.
```
2. `crypto/tls` doesn't actually support multiple key shares and may only keep track of one, so we should just send one