### PR TITLE
Fix data race

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -513,7 +513,8 @@ func (uconn *UConn) generateRandomizedSpec() (ClientHelloSpec, error) {
 	if r.FlipWeightedCoin(0.4) {
 		p.TLSVersMin = VersionTLS10
 		p.TLSVersMax = VersionTLS13
-		tls13ciphers := defaultCipherSuitesTLS13()
+		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13()))
+		copy(tls13ciphers, defaultCipherSuitesTLS13())
 		r.rand.Shuffle(len(tls13ciphers), func(i, j int) {
 			tls13ciphers[i], tls13ciphers[j] = tls13ciphers[j], tls13ciphers[i]
 		})


### PR DESCRIPTION
Copy slice returned by defaultCipherSuitesTLS13 before modifying to prevent data race against underlying varDefaultCipherSuitesTLS13 global variable.

This change simply copies the treatment given to `p.CipherSuites`: https://github.com/refraction-networking/utls/blob/7c97cdb47655017af7126d6c5cd23ace4469d7aa/u_parrots.go#L506-L507

Data race detected with concurrent UConn-based dials:

```
WARNING: DATA RACE
Write at 0x00c0000c808a by goroutine 127:
  .../github.com/refraction-networking/utls.(*UConn).generateRandomizedSpec.func1()
      .../github.com/refraction-networking/utls/u_parrots.go:518 +0x134
  math/rand.(*Rand).Shuffle()
      /usr/local/go/src/math/rand/rand.go:253 +0xc4
  .../github.com/refraction-networking/utls.(*UConn).generateRandomizedSpec()
      .../github.com/refraction-networking/utls/u_parrots.go:517 +0x22e8
  .../github.com/refraction-networking/utls.(*UConn).applyPresetByID()
      .../github.com/refraction-networking/utls/u_parrots.go:330 +0x13f
  .../github.com/refraction-networking/utls.(*UConn).BuildHandshakeState()
      .../github.com/refraction-networking/utls/u_conn.go:77 +0x489

Previous read at 0x00c0000c808a by goroutine 83:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:197 +0x0
  .../github.com/refraction-networking/utls.(*Conn).makeClientHello()
      .../github.com/refraction-networking/utls/handshake_client.go:124 +0x1096
  .../github.com/refraction-networking/utls.(*UConn).ApplyPreset()
      .../github.com/refraction-networking/utls/u_parrots.go:357 +0xdd
  .../github.com/refraction-networking/utls.(*UConn).applyPresetByID()
      .../github.com/refraction-networking/utls/u_parrots.go:344 +0x199
 .../github.com/refraction-networking/utls.(*UConn).BuildHandshakeState()
      .../github.com/refraction-networking/utls/u_conn.go:77 +0x489
```
