### PR TITLE
WIP: fix TLS 1.2 session cache

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -427,6 +427,11 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			}
 			grease_extensions_seen += 1
 		case *SessionTicketExtension:
+			if session == nil && uconn.config.ClientSessionCache != nil {
+				cacheKey := clientSessionCacheKey(uconn.RemoteAddr(), uconn.config)
+				session, _ = uconn.config.ClientSessionCache.Get(cacheKey)
+				// TODO: use uconn.loadSession(hello.getPrivatePtr()) to support TLS 1.3 PSK-style resumption
+			}
 			err := uconn.SetSessionState(session)
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently, SessionCache is not used for non-HelloGolang fingerprints,
and this PR is what the fix would potentially look like.
This is only for the TLS 1.2, support for TLS 1.3 PSK resumption cache remains a TODO.

Supposedly fixes #27, not tested yet

@rod-hynes