### PR TITLE
Fix panic in u_public by never dereferencing

### DIFF
--- a/u_conn.go
+++ b/u_conn.go
@@ -361,7 +361,9 @@ func (c *UConn) clientHandshake() (err error) {
 		}
 		// In TLS 1.3, session tickets are delivered after the handshake.
 		err = hs13.handshake()
-		c.HandshakeState = *hs13.toPublic13()
+		if handshakeState := hs13.toPublic13(); handshakeState != nil {
+			c.HandshakeState = *handshakeState
+		}
 		return err
 	}
 
@@ -369,7 +371,9 @@ func (c *UConn) clientHandshake() (err error) {
 	hs12.serverHello = serverHello
 	hs12.hello = hello
 	err = hs12.handshake()
-	c.HandshakeState = *hs12.toPublic12()
+	if handshakeState := hs12.toPublic12(); handshakeState != nil {
+		c.HandshakeState = *handshakeState
+	}
 	if err != nil {
 		return err
 	}

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -567,7 +567,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			if session == nil && uconn.config.ClientSessionCache != nil {
 				cacheKey := clientSessionCacheKey(uconn.RemoteAddr(), uconn.config)
 				session, _ = uconn.config.ClientSessionCache.Get(cacheKey)
-				// TODO: use uconn.loadSession(hello.getPrivatePtr()) to support TLS 1.3 PSK-style resumption
+				// TODO: use uconn.loadSession(hello.getPrivateObj()) to support TLS 1.3 PSK-style resumption
 			}
 			err := uconn.SetSessionState(session)
 			if err != nil {

--- a/u_public.go
+++ b/u_public.go
@@ -121,7 +121,7 @@ func (chs *ClientHandshakeState) toPrivate12() *clientHandshakeState {
 
 			masterSecret: chs.MasterSecret,
 
-			finishedHash: *chs.State12.FinishedHash.getPrivatePtr(),
+			finishedHash: chs.State12.FinishedHash.getPrivateObj(),
 
 			uconn: chs.uconn,
 		}
@@ -133,8 +133,8 @@ func (chs12 *clientHandshakeState) toPublic12() *ClientHandshakeState {
 		return nil
 	} else {
 		tls12State := TLS12OnlyState{
-			Suite:        *chs12.suite.getPublicPtr(),
-			FinishedHash: *chs12.finishedHash.getPublicPtr(),
+			Suite:        chs12.suite.getPublicObj(),
+			FinishedHash: chs12.finishedHash.getPublicObj(),
 		}
 		return &ClientHandshakeState{
 			C:           chs12.c,
@@ -455,11 +455,11 @@ func (cs *CipherSuite) getPrivatePtr() *cipherSuite {
 	}
 }
 
-func (cs *cipherSuite) getPublicPtr() *CipherSuite {
+func (cs *cipherSuite) getPublicObj() CipherSuite {
 	if cs == nil {
-		return nil
+		return CipherSuite{}
 	} else {
-		return &CipherSuite{
+		return CipherSuite{
 			Id:     cs.id,
 			KeyLen: cs.keyLen,
 			MacLen: cs.macLen,
@@ -490,11 +490,11 @@ type FinishedHash struct {
 	Prf     func(result, secret, label, seed []byte)
 }
 
-func (fh *FinishedHash) getPrivatePtr() *finishedHash {
+func (fh *FinishedHash) getPrivateObj() finishedHash {
 	if fh == nil {
-		return nil
+		return finishedHash{}
 	} else {
-		return &finishedHash{
+		return finishedHash{
 			client:    fh.Client,
 			server:    fh.Server,
 			clientMD5: fh.ClientMD5,
@@ -506,11 +506,11 @@ func (fh *FinishedHash) getPrivatePtr() *finishedHash {
 	}
 }
 
-func (fh *finishedHash) getPublicPtr() *FinishedHash {
+func (fh *finishedHash) getPublicObj() FinishedHash {
 	if fh == nil {
-		return nil
+		return FinishedHash{}
 	} else {
-		return &FinishedHash{
+		return FinishedHash{
 			Client:    fh.client,
 			Server:    fh.server,
 			ClientMD5: fh.clientMD5,


### PR DESCRIPTION
In order to avoid panics, we make sure that no pointer is dereferenced
during transformation between public and private handshake state.
Presumably fixes #29