### PR TITLE
Fix openssl command arguments for update tests

### DIFF
--- a/u_conn_test.go
+++ b/u_conn_test.go
@@ -135,7 +135,7 @@ func TestUTLSHandshakeClientParrotChrome_58_setclienthello(t *testing.T) {
 	opensslCipherName := "ECDHE-RSA-AES128-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-setclienthello-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -152,7 +152,7 @@ func TestUTLSHelloRetryRequest(t *testing.T) {
 
 	test := &clientTest{
 		name:    "UTLS-HelloRetryRequest-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", "ECDHE-RSA-AES128-GCM-SHA256", "-curves", "P-256"},
+		args: []string{"-cipher", "ECDHE-RSA-AES128-GCM-SHA256", "-curves", "P-256"},
 		config:  config,
 	}
 
@@ -184,7 +184,7 @@ func testUTLSHandshakeClientECDHE_RSA_AES128_CBC_SHA(t *testing.T, helloID Clien
 	opensslCipherName := "ECDHE-RSA-AES128-SHA"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -196,7 +196,7 @@ func testUTLSHandshakeClientECDHE_RSA_AES256_CBC_SHA(t *testing.T, helloID Clien
 	opensslCipherName := "ECDHE-RSA-AES256-SHA"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -208,7 +208,7 @@ func testUTLSHandshakeClientECDHE_ECDSA_AES128_CBC_SHA(t *testing.T, helloID Cli
 	opensslCipherName := "ECDHE-ECDSA-AES128-SHA"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		cert:    testECDSACertificate,
 		key:     testECDSAPrivateKey,
 		config:  config,
@@ -222,7 +222,7 @@ func testUTLSHandshakeClientECDHE_ECDSA_AES256_CBC_SHA(t *testing.T, helloID Cli
 	opensslCipherName := "ECDHE-ECDSA-AES256-SHA"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		cert:    testECDSACertificate,
 		key:     testECDSAPrivateKey,
 		config:  config,
@@ -236,7 +236,7 @@ func testUTLSHandshakeClientRSA_AES128_GCM_SHA256(t *testing.T, helloID ClientHe
 	opensslCipherName := "AES128-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -249,7 +249,7 @@ func testUTLSHandshakeClientECDHE_ECDSA_AES128_GCM_SHA256(t *testing.T, helloID 
 	opensslCipherName := "ECDHE-ECDSA-AES128-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		cert:    testECDSACertificate,
 		key:     testECDSAPrivateKey,
 		config:  config,
@@ -264,7 +264,7 @@ func testUTLSHandshakeClientECDHE_RSA_AES128_GCM_SHA256(t *testing.T, helloID Cl
 	opensslCipherName := "ECDHE-RSA-AES128-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -276,7 +276,7 @@ func testUTLSHandshakeClientECDHE_ECDSA_AES256_GCM_SHA256(t *testing.T, helloID 
 	opensslCipherName := "ECDHE-ECDSA-AES256-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		cert:    testECDSACertificate,
 		key:     testECDSAPrivateKey,
 		config:  config,
@@ -290,7 +290,7 @@ func testUTLSHandshakeClientECDHE_RSA_AES256_GCM_SHA256(t *testing.T, helloID Cl
 	opensslCipherName := "ECDHE-RSA-AES128-GCM-SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -303,7 +303,7 @@ func testUTLSHandshakeClientTLS13_AES_128_GCM_SHA256(t *testing.T, helloID Clien
 	opensslCipherName := "TLS_AES_128_GCM_SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-ciphersuites", opensslCipherName},
 		config:  config,
 	}
 
@@ -316,7 +316,7 @@ func testUTLSHandshakeClientTLS13_AES_256_GCM_SHA384(t *testing.T, helloID Clien
 	opensslCipherName := "TLS_AES_256_GCM_SHA384"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-ciphersuites", opensslCipherName},
 		config:  config,
 	}
 
@@ -329,7 +329,7 @@ func testUTLSHandshakeClientTLS13_CHACHA20_POLY1305_SHA256(t *testing.T, helloID
 	opensslCipherName := "TLS_CHACHA20_POLY1305_SHA256"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-ciphersuites", opensslCipherName},
 		config:  config,
 	}
 
@@ -342,7 +342,7 @@ func testUTLSHandshakeClientECDHE_RSA_WITH_CHACHA20_POLY1305(t *testing.T, hello
 	opensslCipherName := "ECDHE-RSA-CHACHA20-POLY1305"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 	}
 
@@ -355,7 +355,7 @@ func testUTLSHandshakeClientECDHE_ECDSA_WITH_CHACHA20_POLY1305(t *testing.T, hel
 	opensslCipherName := "ECDHE-ECDSA-CHACHA20-POLY1305"
 	test := &clientTest{
 		name:    "UTLS-" + opensslCipherName + "-" + helloID.Str(),
-		args: []string{"openssl", "s_server", "-cipher", opensslCipherName},
+		args: []string{"-cipher", opensslCipherName},
 		config:  config,
 		cert:    testECDSACertificate,
 		key:     testECDSAPrivateKey,


### PR DESCRIPTION
I've been trying to run the `-update` tests in order to fix the testdata for https://github.com/refraction-networking/utls/pull/38 and ran into a couple issues that I hope this PR addresses.

The first is that it seems as though the openssl command as populated currently ends up as:
```
openssl s_server -no_ticket -num_tickets 0 openssl s_server -cipher TLS_AES_128_GCM_SHA256 -tls1_3 -cert /tmp/go-tls-test334278555 -certform DER -key /tmp/go-tls-test012468798 -accept 24323
```
where `openssl` is repeated. It looks to me like the `openssl s_server` is already defined in https://github.com/refraction-networking/utls/blob/master/handshake_client_test.go#L170 so we can remove the `"openssl", "s_server"` values from the `args` slice.

The other is changing the `-cipher` flag to `-ciphersuites` for TLSv1.3. From https://www.openssl.org/docs/man1.1.1/man1/s_server.html 
```
-cipher val

    This allows the list of TLSv1.2 and below ciphersuites used by the server to be modified. This list is combined with any TLSv1.3 ciphersuites that have been configured. When the client sends a list of supported ciphers the first client cipher also included in the server list is used. Because the client specifies the preference order, the order of the server cipherlist is irrelevant. See the ciphers command for more information.
-ciphersuites val

    This allows the list of TLSv1.3 ciphersuites used by the server to be modified. This list is combined with any TLSv1.2 and below ciphersuites that have been configured. When the client sends a list of supported ciphers the first client cipher also included in the server list is used. Because the client specifies the preference order, the order of the server cipherlist is irrelevant. See the ciphers command for more information. The format for this list is a simple colon (":") separated list of TLSv1.3 ciphersuite names.
```

One note I should make is that running the tests with the `-update` flag changes the testdata from the current `master`. I suppose they would no matter what because the server random will change, so I haven't included those diffs in this PR. 


Let me know what you think/if there's anything else you'd like to see. Thanks!!
