### PR TITLE
Support for TLS1.2 SessionID Based Resumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Some customizations(such as setting session ticket/clientHello) have easy-to-use
     sessionState := utls.MakeClientSessionState(sessionTicket, uint16(tls.VersionTLS12),
         tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         masterSecret,
-        nil, nil)
+        nil, nil, nil)
     tlsConn.SetSessionState(sessionState)
 ```
 

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -138,7 +138,7 @@ func HttpGetTicket(hostname string, addr string) (*http.Response, error) {
 	sessionState := tls.MakeClientSessionState(sessionTicket, uint16(tls.VersionTLS12),
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		masterSecret,
-		nil, nil)
+		nil, nil, nil)
 
 	err = uTlsConn.SetSessionState(sessionState)
 	if err != nil {
@@ -172,7 +172,7 @@ func HttpGetTicketHelloID(hostname string, addr string, helloID tls.ClientHelloI
 	sessionState := tls.MakeClientSessionState(sessionTicket, uint16(tls.VersionTLS12),
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		masterSecret,
-		nil, nil)
+		nil, nil, nil)
 
 	uTlsConn.SetSessionState(sessionState)
 	err = uTlsConn.Handshake()

--- a/tls_test.go
+++ b/tls_test.go
@@ -667,6 +667,8 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf(map[string]*Certificate{"a": nil}))
 		case "RootCAs", "ClientCAs":
 			f.Set(reflect.ValueOf(x509.NewCertPool()))
+		case "ServerSessionCache":
+			f.Set(reflect.ValueOf(newServerSessionCache()))
 		case "ClientSessionCache":
 			f.Set(reflect.ValueOf(NewLRUClientSessionCache(10)))
 		case "KeyLogWriter":
@@ -677,7 +679,7 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf("b"))
 		case "ClientAuth":
 			f.Set(reflect.ValueOf(VerifyClientCertIfGiven))
-		case "InsecureSkipVerify", "SessionTicketsDisabled", "DynamicRecordSizingDisabled", "PreferServerCipherSuites":
+		case "InsecureSkipVerify", "SessionTicketsDisabled", "DynamicRecordSizingDisabled", "PreferServerCipherSuites", "SessionIdEnabled":
 			f.Set(reflect.ValueOf(true))
 		case "MinVersion", "MaxVersion":
 			f.Set(reflect.ValueOf(uint16(VersionTLS12)))

--- a/u_public.go
+++ b/u_public.go
@@ -564,14 +564,20 @@ func MakeClientSessionState(
 	CipherSuite uint16,
 	MasterSecret []byte,
 	ServerCertificates []*x509.Certificate,
-	VerifiedChains [][]*x509.Certificate) *ClientSessionState {
+	VerifiedChains [][]*x509.Certificate,
+	SessionId []uint8) *ClientSessionState {
 	css := ClientSessionState{sessionTicket: SessionTicket,
 		vers:               Vers,
 		cipherSuite:        CipherSuite,
 		masterSecret:       MasterSecret,
 		serverCertificates: ServerCertificates,
-		verifiedChains:     VerifiedChains}
+		verifiedChains:     VerifiedChains,
+		sessionId:          SessionId}
 	return &css
+}
+
+func (css *ClientSessionState) SessionId() []uint8 {
+	return css.sessionId
 }
 
 // Encrypted ticket used for session resumption with server


### PR DESCRIPTION
Add support for TLS1.2 session ID based resumption. Some clients notably iOS NSURLSession by default only support session id based resumption for TLS1.2 so it would be useful to be able to support session id based resumption.

This adds SessionIdEnabled which defaults to false to preserve backwards compatibility and ServerSessionCache for storing sessionId based sessions to the tls Config object. We do not supply an implementation of ServerSessionCache like the LRU client cache. I am not particularly interested in getting session id based resumption working for the server and only have provided an implementation so the client implementation can easily be tested.

The changes to the normal Golang TLS server/client seem straight forward but I'm not so sure about the uTLS changes in particular ApplyPresets which now unconditionally calls SetSessionState whereas previously it only called SetSessionState if the SessionTicketExtension was present. Also, the SetSessionCache method now does not make sense since it unconditionally sets `TicketSupported = true` even though the `SessionCache` can now be used without session tickets.

