### PR TITLE
Document adding custom fake TLS extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,13 @@ func (e *FakeDelegatedCredentialsExtension) Read(b []byte) (n int, err error) {
 	// Extension type
 	appendUint16(fakeDelegatedCredentials)
 
+	algosLength := 2 * len(e.SignatureAlgorithms)
+
 	// Extension data length
-	appendUint16(uint16(len(e.SignatureAlgorithms)) + 2)
+	appendUint16(uint16(algosLength) + 2)
 
 	// Algorithms list length
-	appendUint16(uint16(len(e.SignatureAlgorithms)))
+	appendUint16(uint16(algosLength))
 
 	// Algorithms list
 	for _, a := range e.SignatureAlgorithms {


### PR DESCRIPTION
I see a lot of people asking to add support for a specific extensions (for example, #113, #108, #107). However, the need is often to match required TLS ClientHello fingerprint and not to actually implement functionality required by such extensions. uTLS already has `Fake*` extensions which only serve as a placeholders, and `GenericExtension`, which (as stated in comments) "allows to include in ClientHello arbitrary unsupported extensions".

Thus I'd like to contribute documentation on creating such extensions.