### PR TITLE
new ClientHellos and Extensions 

### DIFF
--- a/common.go
+++ b/common.go
@@ -97,7 +97,6 @@ const (
 	extensionKeyShare                uint16 = 51
 	extensionNextProtoNeg            uint16 = 13172 // not IANA assigned
 	extensionALPS                    uint16 = 17513
-	extensionApplicationSettings     uint16 = 0x4469
 	extensionRenegotiationInfo       uint16 = 0xff01
 )
 

--- a/common.go
+++ b/common.go
@@ -85,6 +85,7 @@ const (
 	extensionSignatureAlgorithms     uint16 = 13
 	extensionALPN                    uint16 = 16
 	extensionSCT                     uint16 = 18
+	extensionDelegatedCredentials    uint16 = 34
 	extensionSessionTicket           uint16 = 35
 	extensionPreSharedKey            uint16 = 41
 	extensionEarlyData               uint16 = 42
@@ -96,6 +97,7 @@ const (
 	extensionKeyShare                uint16 = 51
 	extensionNextProtoNeg            uint16 = 13172 // not IANA assigned
 	extensionALPS                    uint16 = 17513
+	extensionApplicationSettings     uint16 = 0x4469
 	extensionRenegotiationInfo       uint16 = 0xff01
 )
 

--- a/u_common.go
+++ b/u_common.go
@@ -146,14 +146,15 @@ var (
 	HelloRandomizedNoALPN = ClientHelloID{helloRandomizedNoALPN, helloAutoVers, nil}
 
 	// The rest will will parrot given browser.
-	HelloFirefox_Auto = HelloFirefox_99
+	HelloFirefox_Auto = HelloFirefox_102
 	HelloFirefox_55   = ClientHelloID{helloFirefox, "55", nil}
 	HelloFirefox_56   = ClientHelloID{helloFirefox, "56", nil}
 	HelloFirefox_63   = ClientHelloID{helloFirefox, "63", nil}
 	HelloFirefox_65   = ClientHelloID{helloFirefox, "65", nil}
 	HelloFirefox_99   = ClientHelloID{helloFirefox, "99", nil}
+	HelloFirefox_102  = ClientHelloID{helloFirefox, "102", nil}
 
-	HelloChrome_Auto = HelloChrome_100
+	HelloChrome_Auto = HelloChrome_102
 	HelloChrome_58   = ClientHelloID{helloChrome, "58", nil}
 	HelloChrome_62   = ClientHelloID{helloChrome, "62", nil}
 	HelloChrome_70   = ClientHelloID{helloChrome, "70", nil}
@@ -161,9 +162,10 @@ var (
 	HelloChrome_83   = ClientHelloID{helloChrome, "83", nil}
 	HelloChrome_87   = ClientHelloID{helloChrome, "87", nil}
 	HelloChrome_96   = ClientHelloID{helloChrome, "96", nil}
-	HelloChrome_100  = ClientHelloID{helloFirefox, "100", nil}
+	HelloChrome_100  = ClientHelloID{helloChrome, "100", nil}
+	HelloChrome_102  = ClientHelloID{helloChrome, "102", nil}
 
-	HelloIOS_Auto = HelloIOS_12_1
+	HelloIOS_Auto = HelloIOS_14
 	HelloIOS_11_1 = ClientHelloID{helloIOS, "111", nil} // legacy "111" means 11.1
 	HelloIOS_12_1 = ClientHelloID{helloIOS, "12.1", nil}
 	HelloIOS_13   = ClientHelloID{helloIOS, "13", nil}

--- a/u_common.go
+++ b/u_common.go
@@ -146,13 +146,14 @@ var (
 	HelloRandomizedNoALPN = ClientHelloID{helloRandomizedNoALPN, helloAutoVers, nil}
 
 	// The rest will will parrot given browser.
-	HelloFirefox_Auto = HelloFirefox_65
+	HelloFirefox_Auto = HelloFirefox_99
 	HelloFirefox_55   = ClientHelloID{helloFirefox, "55", nil}
 	HelloFirefox_56   = ClientHelloID{helloFirefox, "56", nil}
 	HelloFirefox_63   = ClientHelloID{helloFirefox, "63", nil}
 	HelloFirefox_65   = ClientHelloID{helloFirefox, "65", nil}
+	HelloFirefox_99   = ClientHelloID{helloFirefox, "99", nil}
 
-	HelloChrome_Auto = HelloChrome_83
+	HelloChrome_Auto = HelloChrome_100
 	HelloChrome_58   = ClientHelloID{helloChrome, "58", nil}
 	HelloChrome_62   = ClientHelloID{helloChrome, "62", nil}
 	HelloChrome_70   = ClientHelloID{helloChrome, "70", nil}
@@ -160,6 +161,7 @@ var (
 	HelloChrome_83   = ClientHelloID{helloChrome, "83", nil}
 	HelloChrome_87   = ClientHelloID{helloChrome, "87", nil}
 	HelloChrome_96   = ClientHelloID{helloChrome, "96", nil}
+	HelloChrome_100  = ClientHelloID{helloFirefox, "100", nil}
 
 	HelloIOS_Auto = HelloIOS_12_1
 	HelloIOS_11_1 = ClientHelloID{helloIOS, "111", nil} // legacy "111" means 11.1

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -424,7 +424,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&UtlsCompressCertExtension{[]CertCompressionAlgo{
 					CertCompressionBrotli,
 				}},
-				&ALPSExtension{SupportedProtocols: []string{"h2"}},
+				&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
 				&UtlsGREASEExtension{},
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			},
@@ -509,11 +509,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 					CertCompressionBrotli,
 				}},
 				&UtlsGREASEExtension{},
-				&ApplicationSettingsExtension{
-					SupportedALPNList: []string{
-						"h2",
-					},
-				},
+				&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			},
 		}, nil
@@ -636,6 +632,78 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&FakeRecordSizeLimitExtension{0x4001},
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			}}, nil
+	case HelloChrome_102:
+		return ClientHelloSpec{
+			CipherSuites: []uint16{
+				GREASE_PLACEHOLDER,
+				TLS_AES_128_GCM_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				0x00, // compressionNone
+			},
+			Extensions: []TLSExtension{
+				&UtlsGREASEExtension{},
+				&SNIExtension{},
+				&UtlsExtendedMasterSecretExtension{},
+				&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient},
+				&SupportedCurvesExtension{[]CurveID{
+					GREASE_PLACEHOLDER,
+					X25519,
+					CurveP256,
+					CurveP384,
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{
+					0x00, // pointFormatUncompressed
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}},
+				&StatusRequestExtension{},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{
+					ECDSAWithP256AndSHA256,
+					PSSWithSHA256,
+					PKCS1WithSHA256,
+					ECDSAWithP384AndSHA384,
+					PSSWithSHA384,
+					PKCS1WithSHA384,
+					PSSWithSHA512,
+					PKCS1WithSHA512,
+				}},
+				&SCTExtension{},
+				&KeyShareExtension{[]KeyShare{
+					{Group: CurveID(GREASE_PLACEHOLDER), Data: []byte{0}},
+					{Group: X25519},
+				}},
+				&PSKKeyExchangeModesExtension{[]uint8{
+					PskModeDHE,
+				}},
+				&SupportedVersionsExtension{[]uint16{
+					GREASE_PLACEHOLDER,
+					VersionTLS13,
+					VersionTLS12,
+				}},
+				&UtlsCompressCertExtension{[]CertCompressionAlgo{
+					CertCompressionBrotli,
+				}},
+				&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
+				&UtlsGREASEExtension{},
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
+			},
+		}, nil
+
 	case HelloFirefox_99:
 		return ClientHelloSpec{
 			TLSVersMin: VersionTLS10,
@@ -698,6 +766,85 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 					VersionTLS12,
 					VersionTLS11,
 					VersionTLS10,
+				}},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{ //signature_algorithms
+					ECDSAWithP256AndSHA256,
+					ECDSAWithP384AndSHA384,
+					ECDSAWithP521AndSHA512,
+					PSSWithSHA256,
+					PSSWithSHA384,
+					PSSWithSHA512,
+					PKCS1WithSHA256,
+					PKCS1WithSHA384,
+					PKCS1WithSHA512,
+					ECDSAWithSHA1,
+					PKCS1WithSHA1,
+				}},
+				&PSKKeyExchangeModesExtension{[]uint8{ //psk_key_exchange_modes
+					PskModeDHE,
+				}},
+				&FakeRecordSizeLimitExtension{Limit: 0x4001},             //record_size_limit
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle}, //padding
+			}}, nil
+	case HelloFirefox_102:
+		return ClientHelloSpec{
+			TLSVersMin: VersionTLS10,
+			TLSVersMax: VersionTLS13,
+			CipherSuites: []uint16{
+				TLS_AES_128_GCM_SHA256,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				compressionNone,
+			},
+			Extensions: []TLSExtension{
+				&SNIExtension{},                      //server_name
+				&UtlsExtendedMasterSecretExtension{}, //extended_master_secret
+				&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient}, //extensionRenegotiationInfo
+				&SupportedCurvesExtension{[]CurveID{ //supported_groups
+					X25519,
+					CurveP256,
+					CurveP384,
+					CurveP521,
+					CurveID(FakeFFDHE2048),
+					CurveID(FakeFFDHE3072),
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{ //ec_point_formats
+					pointFormatUncompressed,
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2"}}, //application_layer_protocol_negotiation
+				&StatusRequestExtension{},
+				&DelegatedCredentialsExtension{
+					AlgorithmsSignature: []SignatureScheme{ //signature_algorithms
+						ECDSAWithP256AndSHA256,
+						ECDSAWithP384AndSHA384,
+						ECDSAWithP521AndSHA512,
+						ECDSAWithSHA1,
+					},
+				},
+				&KeyShareExtension{[]KeyShare{
+					{Group: X25519},
+					{Group: CurveP256}, //key_share
+				}},
+				&SupportedVersionsExtension{[]uint16{
+					VersionTLS13, //supported_versions
+					VersionTLS12,
 				}},
 				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{ //signature_algorithms
 					ECDSAWithP256AndSHA256,

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -429,6 +429,94 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			},
 		}, nil
+	case HelloChrome_100:
+		signatureScheme := []SignatureScheme{
+			ECDSAWithP256AndSHA256,
+			ECDSAWithP384AndSHA384,
+			ECDSAWithP521AndSHA512,
+			PSSWithSHA256,
+			PSSWithSHA384,
+			PSSWithSHA512,
+			0x0809,
+			0x080a,
+			0x080b,
+			PKCS1WithSHA256,
+			PKCS1WithSHA384,
+			PKCS1WithSHA512,
+			0x0402,
+			0x0303,
+			0x0301,
+			0x0302,
+			0x0203,
+			0x0201,
+			0x0202,
+		}
+		return ClientHelloSpec{
+			CipherSuites: []uint16{
+				GREASE_PLACEHOLDER,
+				TLS_AES_128_GCM_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				0x00, // compressionNone
+			},
+			Extensions: []TLSExtension{
+				&UtlsGREASEExtension{},
+				&SNIExtension{},
+				&UtlsExtendedMasterSecretExtension{},
+				&RenegotiationInfoExtension{},
+				&SupportedCurvesExtension{[]CurveID{
+					GREASE_PLACEHOLDER,
+					X25519,
+					CurveP256,
+					CurveP384,
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{
+					0x00, // pointFormatUncompressed
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}},
+				&StatusRequestExtension{},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: signatureScheme},
+				&SCTExtension{},
+				&KeyShareExtension{[]KeyShare{
+					{Group: CurveID(GREASE_PLACEHOLDER), Data: []byte{0}},
+					{Group: X25519},
+				}},
+				&PSKKeyExchangeModesExtension{[]uint8{
+					PskModeDHE,
+				}},
+				&SupportedVersionsExtension{[]uint16{
+					VersionTLS13,
+					VersionTLS12,
+					VersionTLS11,
+					VersionTLS10,
+				}},
+				&UtlsCompressCertExtension{[]CertCompressionAlgo{
+					CertCompressionBrotli,
+				}},
+				&UtlsGREASEExtension{},
+				&ApplicationSettingsExtension{
+					SupportedALPNList: []string{
+						"h2",
+					},
+				},
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
+			},
+		}, nil
 	case HelloFirefox_55, HelloFirefox_56:
 		return ClientHelloSpec{
 			TLSVersMax: VersionTLS12,
@@ -547,6 +635,88 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&PSKKeyExchangeModesExtension{[]uint8{pskModeDHE}},
 				&FakeRecordSizeLimitExtension{0x4001},
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
+			}}, nil
+	case HelloFirefox_99:
+		return ClientHelloSpec{
+			TLSVersMin: VersionTLS10,
+			TLSVersMax: VersionTLS13,
+			CipherSuites: []uint16{
+				TLS_AES_128_GCM_SHA256,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				compressionNone,
+			},
+			Extensions: []TLSExtension{
+				&SNIExtension{},                      //server_name
+				&UtlsExtendedMasterSecretExtension{}, //extended_master_secret
+				&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient}, //extensionRenegotiationInfo
+				&SupportedCurvesExtension{[]CurveID{ //supported_groups
+					X25519,
+					CurveP256,
+					CurveP384,
+					CurveP521,
+					CurveID(FakeFFDHE2048),
+					CurveID(FakeFFDHE3072),
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{ //ec_point_formats
+					pointFormatUncompressed,
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}}, //application_layer_protocol_negotiation
+				&StatusRequestExtension{},
+				&DelegatedCredentialsExtension{
+					AlgorithmsSignature: []SignatureScheme{ //signature_algorithms
+						ECDSAWithP256AndSHA256,
+						ECDSAWithP384AndSHA384,
+						ECDSAWithP521AndSHA512,
+						ECDSAWithSHA1,
+					},
+				},
+				&KeyShareExtension{[]KeyShare{
+					{Group: X25519},
+					{Group: CurveP256}, //key_share
+				}},
+				&SupportedVersionsExtension{[]uint16{
+					VersionTLS13, //supported_versions
+					VersionTLS12,
+					VersionTLS11,
+					VersionTLS10,
+				}},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{ //signature_algorithms
+					ECDSAWithP256AndSHA256,
+					ECDSAWithP384AndSHA384,
+					ECDSAWithP521AndSHA512,
+					PSSWithSHA256,
+					PSSWithSHA384,
+					PSSWithSHA512,
+					PKCS1WithSHA256,
+					PKCS1WithSHA384,
+					PKCS1WithSHA512,
+					ECDSAWithSHA1,
+					PKCS1WithSHA1,
+				}},
+				&PSKKeyExchangeModesExtension{[]uint8{ //psk_key_exchange_modes
+					PskModeDHE,
+				}},
+				&FakeRecordSizeLimitExtension{Limit: 0x4001},             //record_size_limit
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle}, //padding
 			}}, nil
 	case HelloIOS_11_1:
 		return ClientHelloSpec{

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -356,15 +356,15 @@ func (e *ALPNExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
-type ALPSExtension struct {
+type ApplicationSettingsExtension struct {
 	SupportedProtocols []string
 }
 
-func (e *ALPSExtension) writeToUConn(uc *UConn) error {
+func (e *ApplicationSettingsExtension) writeToUConn(uc *UConn) error {
 	return nil
 }
 
-func (e *ALPSExtension) Len() int {
+func (e *ApplicationSettingsExtension) Len() int {
 	bLen := 2 + 2 + 2 // Type + Length + ALPS Extension length
 	for _, s := range e.SupportedProtocols {
 		bLen += 1 + len(s) // Supported ALPN Length + actual length of protocol
@@ -372,7 +372,7 @@ func (e *ALPSExtension) Len() int {
 	return bLen
 }
 
-func (e *ALPSExtension) Read(b []byte) (int, error) {
+func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
 	if len(b) < e.Len() {
 		return 0, io.ErrShortBuffer
 	}
@@ -909,47 +909,5 @@ func (e *DelegatedCredentialsExtension) Read(b []byte) (int, error) {
 		b[6+2*i] = byte(sigAndHash >> 8)
 		b[7+2*i] = byte(sigAndHash)
 	}
-	return e.Len(), io.EOF
-}
-
-type ApplicationSettingsExtension struct {
-	SupportedALPNList []string
-}
-
-func (e *ApplicationSettingsExtension) writeToUConn(uc *UConn) error {
-	return nil
-}
-
-func (e *ApplicationSettingsExtension) Len() int {
-	result := 6 //id + first length + second length
-	for _, element := range e.SupportedALPNList {
-		result += 1 + len(element) //byte for string length + allocation for string in bytes
-	}
-	return result
-}
-
-func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
-	if len(b) < e.Len() {
-		return 0, io.ErrShortBuffer
-	}
-
-	b[0] = byte(extensionApplicationSettings >> 8)
-	b[1] = byte(0x69)
-	currentIndex := 6
-
-	for _, alpn := range e.SupportedALPNList {
-		b[currentIndex] = byte(len(alpn)) //set length of string in bytes
-		currentIndex++
-		for _, char := range alpn {
-			b[currentIndex] = byte(char) //convert char to byte
-			currentIndex++
-		}
-	}
-
-	b[2] = 0x00
-	b[3] = byte(e.Len() - 4) //len minus id and itself (2+2)
-	b[4] = 0x00
-	b[5] = byte(e.Len() - 6) //len minus id big length and itself 5 (2+2+2)
-
 	return e.Len(), io.EOF
 }

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -79,7 +79,7 @@ func (e *SNIExtension) Read(b []byte) (int, error) {
 	b[0] = byte(extensionServerName >> 8)
 	b[1] = byte(extensionServerName)
 	b[2] = byte((len(hostName) + 5) >> 8)
-	b[3] = byte((len(hostName) + 5))
+	b[3] = byte(len(hostName) + 5)
 	b[4] = byte((len(hostName) + 3) >> 8)
 	b[5] = byte(len(hostName) + 3)
 	// b[6] Server Name Type: host_name (0)
@@ -115,6 +115,36 @@ func (e *StatusRequestExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+type StatusRequestV2Extension struct {
+}
+
+func (e *StatusRequestV2Extension) writeToUConn(uc *UConn) error {
+	uc.HandshakeState.Hello.OcspStapling = true
+	return nil
+}
+
+func (e *StatusRequestV2Extension) Len() int {
+	return 13
+}
+
+func (e *StatusRequestV2Extension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+	// RFC 4366, section 3.6
+	b[0] = byte(17 >> 8)
+	b[1] = byte(17)
+	b[2] = 0
+	b[3] = 9
+	b[4] = 0
+	b[5] = 7
+	b[6] = 2 // OCSP type
+	b[7] = 0
+	b[8] = 4
+	// Two zero valued uint16s for the two lengths.
+	return e.Len(), io.EOF
+}
+
 type SupportedCurvesExtension struct {
 	Curves []CurveID
 }
@@ -137,9 +167,9 @@ func (e *SupportedCurvesExtension) Read(b []byte) (int, error) {
 	b[0] = byte(extensionSupportedCurves >> 8)
 	b[1] = byte(extensionSupportedCurves)
 	b[2] = byte((2 + 2*len(e.Curves)) >> 8)
-	b[3] = byte((2 + 2*len(e.Curves)))
+	b[3] = byte(2 + 2*len(e.Curves))
 	b[4] = byte((2 * len(e.Curves)) >> 8)
-	b[5] = byte((2 * len(e.Curves)))
+	b[5] = byte(2 * len(e.Curves))
 	for i, curve := range e.Curves {
 		b[6+2*i] = byte(curve >> 8)
 		b[7+2*i] = byte(curve)
@@ -168,8 +198,8 @@ func (e *SupportedPointsExtension) Read(b []byte) (int, error) {
 	b[0] = byte(extensionSupportedPoints >> 8)
 	b[1] = byte(extensionSupportedPoints)
 	b[2] = byte((1 + len(e.SupportedPoints)) >> 8)
-	b[3] = byte((1 + len(e.SupportedPoints)))
-	b[4] = byte((len(e.SupportedPoints)))
+	b[3] = byte(1 + len(e.SupportedPoints))
+	b[4] = byte(len(e.SupportedPoints))
 	for i, pointFormat := range e.SupportedPoints {
 		b[5+i] = pointFormat
 	}
@@ -197,9 +227,40 @@ func (e *SignatureAlgorithmsExtension) Read(b []byte) (int, error) {
 	b[0] = byte(extensionSignatureAlgorithms >> 8)
 	b[1] = byte(extensionSignatureAlgorithms)
 	b[2] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)) >> 8)
-	b[3] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)))
+	b[3] = byte(2 + 2*len(e.SupportedSignatureAlgorithms))
 	b[4] = byte((2 * len(e.SupportedSignatureAlgorithms)) >> 8)
-	b[5] = byte((2 * len(e.SupportedSignatureAlgorithms)))
+	b[5] = byte(2 * len(e.SupportedSignatureAlgorithms))
+	for i, sigAndHash := range e.SupportedSignatureAlgorithms {
+		b[6+2*i] = byte(sigAndHash >> 8)
+		b[7+2*i] = byte(sigAndHash)
+	}
+	return e.Len(), io.EOF
+}
+
+type SignatureAlgorithmsCertExtension struct {
+	SupportedSignatureAlgorithms []SignatureScheme
+}
+
+func (e *SignatureAlgorithmsCertExtension) writeToUConn(uc *UConn) error {
+	uc.HandshakeState.Hello.SupportedSignatureAlgorithms = e.SupportedSignatureAlgorithms
+	return nil
+}
+
+func (e *SignatureAlgorithmsCertExtension) Len() int {
+	return 6 + 2*len(e.SupportedSignatureAlgorithms)
+}
+
+func (e *SignatureAlgorithmsCertExtension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+	// https://tools.ietf.org/html/rfc5246#section-7.4.1.4.1
+	b[0] = byte(extensionSignatureAlgorithmsCert >> 8)
+	b[1] = byte(extensionSignatureAlgorithmsCert)
+	b[2] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)) >> 8)
+	b[3] = byte(2 + 2*len(e.SupportedSignatureAlgorithms))
+	b[4] = byte((2 * len(e.SupportedSignatureAlgorithms)) >> 8)
+	b[5] = byte(2 * len(e.SupportedSignatureAlgorithms))
 	for i, sigAndHash := range e.SupportedSignatureAlgorithms {
 		b[6+2*i] = byte(sigAndHash >> 8)
 		b[7+2*i] = byte(sigAndHash)
@@ -644,9 +705,9 @@ func (e *KeyShareExtension) Read(b []byte) (int, error) {
 	b[1] = byte(extensionKeyShare)
 	keySharesLen := e.keySharesLen()
 	b[2] = byte((keySharesLen + 2) >> 8)
-	b[3] = byte((keySharesLen + 2))
+	b[3] = byte(keySharesLen + 2)
 	b[4] = byte((keySharesLen) >> 8)
-	b[5] = byte((keySharesLen))
+	b[5] = byte(keySharesLen)
 
 	i := 6
 	for _, ks := range e.KeyShares {
@@ -688,7 +749,7 @@ func (e *PSKKeyExchangeModesExtension) Read(b []byte) (int, error) {
 
 	modesLen := len(e.Modes)
 	b[2] = byte((modesLen + 1) >> 8)
-	b[3] = byte((modesLen + 1))
+	b[3] = byte(modesLen + 1)
 	b[4] = byte(modesLen)
 
 	if len(e.Modes) > 0 {
@@ -728,7 +789,7 @@ func (e *SupportedVersionsExtension) Read(b []byte) (int, error) {
 	b[0] = byte(extensionSupportedVersions >> 8)
 	b[1] = byte(extensionSupportedVersions)
 	b[2] = byte((extLen + 1) >> 8)
-	b[3] = byte((extLen + 1))
+	b[3] = byte(extLen + 1)
 	b[4] = byte(extLen)
 
 	i := 5
@@ -819,5 +880,76 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 
 	b[4] = byte(e.Limit >> 8)
 	b[5] = byte(e.Limit & 0xff)
+	return e.Len(), io.EOF
+}
+
+type DelegatedCredentialsExtension struct {
+	AlgorithmsSignature []SignatureScheme
+}
+
+func (e *DelegatedCredentialsExtension) writeToUConn(uc *UConn) error {
+	return nil
+}
+
+func (e *DelegatedCredentialsExtension) Len() int {
+	return 6 + 2*len(e.AlgorithmsSignature)
+}
+
+func (e *DelegatedCredentialsExtension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+	b[0] = byte(extensionDelegatedCredentials >> 8)
+	b[1] = byte(extensionDelegatedCredentials)
+	b[2] = byte((2 + 2*len(e.AlgorithmsSignature)) >> 8)
+	b[3] = byte(2 + 2*len(e.AlgorithmsSignature))
+	b[4] = byte((2 * len(e.AlgorithmsSignature)) >> 8)
+	b[5] = byte(2 * len(e.AlgorithmsSignature))
+	for i, sigAndHash := range e.AlgorithmsSignature {
+		b[6+2*i] = byte(sigAndHash >> 8)
+		b[7+2*i] = byte(sigAndHash)
+	}
+	return e.Len(), io.EOF
+}
+
+type ApplicationSettingsExtension struct {
+	SupportedALPNList []string
+}
+
+func (e *ApplicationSettingsExtension) writeToUConn(uc *UConn) error {
+	return nil
+}
+
+func (e *ApplicationSettingsExtension) Len() int {
+	result := 6 //id + first length + second length
+	for _, element := range e.SupportedALPNList {
+		result += 1 + len(element) //byte for string length + allocation for string in bytes
+	}
+	return result
+}
+
+func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+
+	b[0] = byte(extensionApplicationSettings >> 8)
+	b[1] = byte(0x69)
+	currentIndex := 6
+
+	for _, alpn := range e.SupportedALPNList {
+		b[currentIndex] = byte(len(alpn)) //set length of string in bytes
+		currentIndex++
+		for _, char := range alpn {
+			b[currentIndex] = byte(char) //convert char to byte
+			currentIndex++
+		}
+	}
+
+	b[2] = 0x00
+	b[3] = byte(e.Len() - 4) //len minus id and itself (2+2)
+	b[4] = 0x00
+	b[5] = byte(e.Len() - 6) //len minus id big length and itself 5 (2+2+2)
+
 	return e.Len(), io.EOF
 }


### PR DESCRIPTION
Various ClientHellos and TLS extensions are included in this PR, from [Psiphon-Labs](https://github.com/Psiphon-Labs/utls) , [Noooste](https://github.com/Noooste/utls/), and [sleeyax](https://github.com/sleeyax/utls).
Fingerprints and extensions were tested by comparing Wireshark captures from our ClientHellos to captures from real browsers (and the extensions being used). 


[Psiphon-Labs](https://github.com/Psiphon-Labs/utls) :
- HelloChrome102 (tested) 
- HelloFirefox102 (tested)
- change to HelloRandomized to include ApplicationSettingsExtension 

[sleeyax](https://github.com/sleeyax/utls):
- Chrome_87
- Chrome_96
- iOS_13 (tested)
- iOS14 (tested)
- Android11
- ApplicationSettingsExtension

[Noooste](https://github.com/Noooste/utls/):
- Firefox99 (tested)
- Chrome100 
- SignatureAlgorithmsCertExtension
- DelegatedCredentialsExtension 
- StatusRequest Extension




