### PR TITLE
feat: Chrome 106 Shuffled Fingerprint

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -183,6 +183,7 @@ var (
 	HelloChrome_96   = ClientHelloID{helloChrome, "96", nil}
 	HelloChrome_100  = ClientHelloID{helloChrome, "100", nil}
 	HelloChrome_102  = ClientHelloID{helloChrome, "102", nil}
+	HelloChrome_107  = ClientHelloID{helloChrome, "107", nil} // beta: shuffler enabled
 
 	HelloIOS_Auto = HelloIOS_14
 	HelloIOS_11_1 = ClientHelloID{helloIOS, "111", nil} // legacy "111" means 11.1

--- a/u_common.go
+++ b/u_common.go
@@ -173,17 +173,17 @@ var (
 	HelloFirefox_102  = ClientHelloID{helloFirefox, "102", nil}
 	HelloFirefox_105  = ClientHelloID{helloFirefox, "105", nil}
 
-	HelloChrome_Auto = HelloChrome_102
-	HelloChrome_58   = ClientHelloID{helloChrome, "58", nil}
-	HelloChrome_62   = ClientHelloID{helloChrome, "62", nil}
-	HelloChrome_70   = ClientHelloID{helloChrome, "70", nil}
-	HelloChrome_72   = ClientHelloID{helloChrome, "72", nil}
-	HelloChrome_83   = ClientHelloID{helloChrome, "83", nil}
-	HelloChrome_87   = ClientHelloID{helloChrome, "87", nil}
-	HelloChrome_96   = ClientHelloID{helloChrome, "96", nil}
-	HelloChrome_100  = ClientHelloID{helloChrome, "100", nil}
-	HelloChrome_102  = ClientHelloID{helloChrome, "102", nil}
-	HelloChrome_107  = ClientHelloID{helloChrome, "107", nil} // beta: shuffler enabled
+	HelloChrome_Auto        = HelloChrome_102
+	HelloChrome_58          = ClientHelloID{helloChrome, "58", nil}
+	HelloChrome_62          = ClientHelloID{helloChrome, "62", nil}
+	HelloChrome_70          = ClientHelloID{helloChrome, "70", nil}
+	HelloChrome_72          = ClientHelloID{helloChrome, "72", nil}
+	HelloChrome_83          = ClientHelloID{helloChrome, "83", nil}
+	HelloChrome_87          = ClientHelloID{helloChrome, "87", nil}
+	HelloChrome_96          = ClientHelloID{helloChrome, "96", nil}
+	HelloChrome_100         = ClientHelloID{helloChrome, "100", nil}
+	HelloChrome_102         = ClientHelloID{helloChrome, "102", nil}
+	HelloChrome_106_Shuffle = ClientHelloID{helloChrome, "106", nil} // beta: shuffler enabled starting from 106
 
 	HelloIOS_Auto = HelloIOS_14
 	HelloIOS_11_1 = ClientHelloID{helloIOS, "111", nil} // legacy "111" means 11.1

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -501,7 +501,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			},
 		}, nil
-	case HelloChrome_107:
+	case HelloChrome_106_Shuffle:
 		chs, err := utlsIdToSpec(HelloChrome_102)
 		if err != nil {
 			return chs, err
@@ -1843,7 +1843,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 }
 
 func shuffleExtensions(chs ClientHelloSpec) (ClientHelloSpec, error) {
-	// Shuffle extensions to avoid fingerprinting -- introduced in Chrome 107
+	// Shuffle extensions to avoid fingerprinting -- introduced in Chrome 106
 	// GREASE, padding will remain in place (if present)
 
 	// Find indexes of GREASE and padding extensions


### PR DESCRIPTION
Fixes #132. 

- added `HelloChrome_107` (commented as beta and not used by `HelloChrome_Auto`)
- added `shuffleExtensions()` to shuffle the order of extensions in a `ClientHelloSpec`
