### PR TITLE
Exports `utlsIdToSpec()` as `UTLSIdToSpec()`

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -14,10 +14,10 @@ import (
 	"strconv"
 )
 
-// UtlsIdSpec converts a ClientHelloID to a corresponding ClientHelloSpec.
+// UTLSIdToSpec converts a ClientHelloID to a corresponding ClientHelloSpec.
 //
 // Exported internal function utlsIdToSpec per request.
-func UtlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
+func UTLSIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 	return utlsIdToSpec(id)
 }
 

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -14,6 +14,13 @@ import (
 	"strconv"
 )
 
+// UtlsIdSpec converts a ClientHelloID to a corresponding ClientHelloSpec.
+//
+// Exported internal function utlsIdToSpec per request.
+func UtlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
+	return utlsIdToSpec(id)
+}
+
 func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 	switch id {
 	case HelloChrome_58, HelloChrome_62:


### PR DESCRIPTION
Implements #135: exporting `utlsIdToSpec()` function as `UTLSIdToSpec()` per request.