### PR TITLE
feat: allow custom GREASE value/body

### DIFF
--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -402,7 +402,7 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, e
 
 		default:
 			if isGREASEUint16(extension) {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsGREASEExtension{unGREASEUint16(extension), extData})
+				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsGREASEExtension{Value: unGREASEUint16(extension), Body: extData})
 			} else if f.AllowBluntMimicry {
 				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
 			} else {

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1939,16 +1939,19 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 				ext.ServerName = uconn.config.ServerName
 			}
 		case *UtlsGREASEExtension:
+			grease_extensions_seen += 1
+			if ext.Customized == true { // Requested in #128: allow custom GREASE values
+				continue
+			}
 			switch grease_extensions_seen {
-			case 0:
-				ext.Value = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_extension1)
 			case 1:
+				ext.Value = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_extension1)
+			case 2:
 				ext.Value = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_extension2)
 				ext.Body = []byte{0}
 			default:
 				return errors.New("at most 2 grease extensions are supported")
 			}
-			grease_extensions_seen += 1
 		case *SessionTicketExtension:
 			if session == nil && uconn.config.ClientSessionCache != nil {
 				cacheKey := clientSessionCacheKey(uconn.RemoteAddr(), uconn.config)

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -551,8 +551,9 @@ const (
 
 // it is responsibility of user not to generate multiple grease extensions with same value
 type UtlsGREASEExtension struct {
-	Value uint16
-	Body  []byte // in Chrome first grease has empty body, second grease has a single zero byte
+	Value      uint16
+	Body       []byte // in Chrome first grease has empty body, second grease has a single zero byte
+	Customized bool   // Requested in #128: if set to true, Value and Body are used as is (otherwise uTLS will generate them)
 }
 
 func (e *UtlsGREASEExtension) writeToUConn(uc *UConn) error {


### PR DESCRIPTION
Added a `Customized` flag to avoid overwriting by `ApplyPreset()`.

Fixes #128. 