### PR TITLE
Fix Client Certificate Verification when Using Extended Master Secret

### DIFF
--- a/handshake_client.go
+++ b/handshake_client.go
@@ -600,8 +600,10 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		}
 	}
 
+	// [UTLS SECTION START]
 	/* sessionHash does not include CertificateVerify */
 	sessionHash := hs.finishedHash.Sum()
+	// [UTLS SECTION END]
 
 	if chainToSend != nil && len(chainToSend.Certificate) > 0 {
 		certVerify := &certificateVerifyMsg{}
@@ -651,11 +653,14 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		}
 	}
 
+	// [UTLS SECTION START]
 	if hs.hello.ems && hs.serverHello.ems {
 		hs.masterSecret = extendedMasterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, sessionHash)
 	} else {
 		hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.hello.random, hs.serverHello.random)
 	}
+	// [UTLS SECTION END]
+
 	if err := c.config.writeKeyLog(keyLogLabelTLS12, hs.hello.random, hs.masterSecret); err != nil {
 		c.sendAlert(alertInternalError)
 		return errors.New("tls: failed to write to key log: " + err.Error())

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -600,6 +600,9 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		}
 	}
 
+	/* sessionHash does not include CertificateVerify */
+	sessionHash := hs.finishedHash.Sum()
+
 	if chainToSend != nil && len(chainToSend.Certificate) > 0 {
 		certVerify := &certificateVerifyMsg{}
 
@@ -649,7 +652,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 	}
 
 	if hs.hello.ems && hs.serverHello.ems {
-		hs.masterSecret = extendedMasterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.finishedHash)
+		hs.masterSecret = extendedMasterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, sessionHash)
 	} else {
 		hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.hello.random, hs.serverHello.random)
 	}

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -530,8 +530,7 @@ var extendedMasterSecretLabel = []byte("extended master secret")
 
 // extendedMasterFromPreMasterSecret generates the master secret from the pre-master
 // secret and session hash. See https://tools.ietf.org/html/rfc7627#section-4
-func extendedMasterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret []byte, fh finishedHash) []byte {
-	sessionHash := fh.Sum()
+func extendedMasterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret []byte, sessionHash []byte) []byte {
 	masterSecret := make([]byte, masterSecretLength)
 	prfForVersion(version, suite)(masterSecret, preMasterSecret, extendedMasterSecretLabel, sessionHash)
 	return masterSecret


### PR DESCRIPTION
Currently it is not possible for UTLS clients to connect to OpenSSL servers (and probably any RFC compliant server) when performing mutual TLS authentication and using the extended master secret extension (and using TLSv1.2)

The session hash used in extended master secret does not include the CertificateVerify handshake message. see: https://www.rfc-editor.org/rfc/rfc7627#section-3

```
   When a full TLS handshake takes place, we define

         session_hash = Hash(handshake_messages)

   where "handshake_messages" refers to all handshake messages sent or
   received, starting at the ClientHello up to and including the
   ClientKeyExchange message, including the type and length fields of
   the handshake messages.  This is the concatenation of all the
   exchanged Handshake structures, as defined in Section 7.4 of
   [RFC5246].
```

Note: It should be possible to calculate the master secret on both the client and the server after the client has sent the ClientKeyExchange message. If the CertificateVerify message was part of the hash then this would not be possible on the server. This is also how openssl implements extended master secret. For example you can see from the control flow in openssl that the client key exchange message triggers generating the master key:

```
tls_process_cke_ecdhe -> ssl_derive -> ssl_gensecret -> ssl_generate_master_secret -> tls1_generate_master_secret
```
