### PR TITLE
Refactor: clean up DelegatedCredentialsExtension

### DIFF
--- a/common.go
+++ b/common.go
@@ -91,7 +91,6 @@ const (
 	extensionALPN                    uint16 = 16
 	extensionStatusRequestV2         uint16 = 17
 	extensionSCT                     uint16 = 18
-	extensionDelegatedCredentials    uint16 = 34
 	extensionSessionTicket           uint16 = 35
 	extensionPreSharedKey            uint16 = 41
 	extensionEarlyData               uint16 = 42

--- a/u_common.go
+++ b/u_common.go
@@ -30,13 +30,14 @@ const (
 	utlsExtensionExtendedMasterSecret uint16 = 23    // https://tools.ietf.org/html/rfc7627
 	utlsExtensionCompressCertificate  uint16 = 27    // https://datatracker.ietf.org/doc/html/rfc8879#section-7.1
 	utlsExtensionApplicationSettings  uint16 = 17513 // not IANA assigned
-	utlsFakeExtensionCustom           uint16 = 1234  // not IANA assigned, for ALPS
+
+	utlsFakeExtensionCustom uint16 = 1234 // not IANA assigned, for ALPS
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
 	fakeExtensionTokenBinding         uint16 = 24
+	fakeExtensionDelegatedCredentials uint16 = 34    // https://tools.ietf.org/html/draft-ietf-tls-subcerts-09
 	fakeOldExtensionChannelID         uint16 = 30031 // not IANA assigned
 	fakeExtensionChannelID            uint16 = 30032 // not IANA assigned
-	fakeExtensionDelegatedCredentials uint16 = 34
 )
 
 const (

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -680,8 +680,8 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&SessionTicketExtension{},
 				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}}, //application_layer_protocol_negotiation
 				&StatusRequestExtension{},
-				&DelegatedCredentialsExtension{
-					AlgorithmsSignature: []SignatureScheme{ //signature_algorithms
+				&FakeDelegatedCredentialsExtension{
+					SupportedSignatureAlgorithms: []SignatureScheme{ //signature_algorithms
 						ECDSAWithP256AndSHA256,
 						ECDSAWithP384AndSHA384,
 						ECDSAWithP521AndSHA512,
@@ -761,8 +761,8 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&SessionTicketExtension{},
 				&ALPNExtension{AlpnProtocols: []string{"h2"}}, //application_layer_protocol_negotiation
 				&StatusRequestExtension{},
-				&DelegatedCredentialsExtension{
-					AlgorithmsSignature: []SignatureScheme{ //signature_algorithms
+				&FakeDelegatedCredentialsExtension{
+					SupportedSignatureAlgorithms: []SignatureScheme{ //signature_algorithms
 						ECDSAWithP256AndSHA256,
 						ECDSAWithP384AndSHA384,
 						ECDSAWithP521AndSHA512,

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -891,29 +891,29 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
-type DelegatedCredentialsExtension struct {
-	AlgorithmsSignature []SignatureScheme
+type FakeDelegatedCredentialsExtension struct {
+	SupportedSignatureAlgorithms []SignatureScheme
 }
 
-func (e *DelegatedCredentialsExtension) writeToUConn(uc *UConn) error {
+func (e *FakeDelegatedCredentialsExtension) writeToUConn(uc *UConn) error {
 	return nil
 }
 
-func (e *DelegatedCredentialsExtension) Len() int {
-	return 6 + 2*len(e.AlgorithmsSignature)
+func (e *FakeDelegatedCredentialsExtension) Len() int {
+	return 6 + 2*len(e.SupportedSignatureAlgorithms)
 }
 
-func (e *DelegatedCredentialsExtension) Read(b []byte) (int, error) {
+func (e *FakeDelegatedCredentialsExtension) Read(b []byte) (int, error) {
 	if len(b) < e.Len() {
 		return 0, io.ErrShortBuffer
 	}
-	b[0] = byte(extensionDelegatedCredentials >> 8)
-	b[1] = byte(extensionDelegatedCredentials)
-	b[2] = byte((2 + 2*len(e.AlgorithmsSignature)) >> 8)
-	b[3] = byte(2 + 2*len(e.AlgorithmsSignature))
-	b[4] = byte((2 * len(e.AlgorithmsSignature)) >> 8)
-	b[5] = byte(2 * len(e.AlgorithmsSignature))
-	for i, sigAndHash := range e.AlgorithmsSignature {
+	b[0] = byte(fakeExtensionDelegatedCredentials >> 8)
+	b[1] = byte(fakeExtensionDelegatedCredentials)
+	b[2] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)) >> 8)
+	b[3] = byte(2 + 2*len(e.SupportedSignatureAlgorithms))
+	b[4] = byte((2 * len(e.SupportedSignatureAlgorithms)) >> 8)
+	b[5] = byte(2 * len(e.SupportedSignatureAlgorithms))
+	for i, sigAndHash := range e.SupportedSignatureAlgorithms {
 		b[6+2*i] = byte(sigAndHash >> 8)
 		b[7+2*i] = byte(sigAndHash)
 	}
@@ -950,38 +950,6 @@ func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
 	b[6] = byte(len(e.KeyParameters))
 	if len(e.KeyParameters) > 0 {
 		copy(b[7:], e.KeyParameters)
-	}
-	return e.Len(), io.EOF
-}
-
-// https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15#section-4.1.1
-
-type FakeDelegatedCredentialsExtension struct {
-	SupportedSignatureAlgorithms []SignatureScheme
-}
-
-func (e *FakeDelegatedCredentialsExtension) writeToUConn(uc *UConn) error {
-	return nil
-}
-
-func (e *FakeDelegatedCredentialsExtension) Len() int {
-	return 6 + 2*len(e.SupportedSignatureAlgorithms)
-}
-
-func (e *FakeDelegatedCredentialsExtension) Read(b []byte) (int, error) {
-	if len(b) < e.Len() {
-		return 0, io.ErrShortBuffer
-	}
-	// https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15#section-4.1.1
-	b[0] = byte(fakeExtensionDelegatedCredentials >> 8)
-	b[1] = byte(fakeExtensionDelegatedCredentials)
-	b[2] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)) >> 8)
-	b[3] = byte((2 + 2*len(e.SupportedSignatureAlgorithms)))
-	b[4] = byte((2 * len(e.SupportedSignatureAlgorithms)) >> 8)
-	b[5] = byte((2 * len(e.SupportedSignatureAlgorithms)))
-	for i, sigAndHash := range e.SupportedSignatureAlgorithms {
-		b[6+2*i] = byte(sigAndHash >> 8)
-		b[7+2*i] = byte(sigAndHash)
 	}
 	return e.Len(), io.EOF
 }


### PR DESCRIPTION
- `DelegatedCredentialsExtension` duplicates `FakeDelegatedCredentialsExtension`.
- We will stick to `FakeDelegatedCredentialsExtension` since its functions are not implemented and will break handshake if server echoes it.
- Moving the enum `extensionDelegatedCredentials` out from `common.go`, since upstream `crypto/tls` does not implement it nor provide any definition for it.