### PR TITLE
Properly check GREASE and add FakeEncryptThenMACExtension

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -37,6 +37,7 @@ const (
 	fakeOldExtensionChannelID         uint16 = 30031 // not IANA assigned
 	fakeExtensionChannelID            uint16 = 30032 // not IANA assigned
 	fakeExtensionDelegatedCredentials uint16 = 34
+	fakeExtensionEncryptThenMAC       uint16 = 22
 )
 
 const (

--- a/u_conn.go
+++ b/u_conn.go
@@ -596,7 +596,7 @@ func (uconn *UConn) SetTLSVers(minTLSVers, maxTLSVers uint16, specExtensions []T
 					minVers := uint16(0)
 					maxVers := uint16(0)
 					for _, vers := range versions {
-						if vers == GREASE_PLACEHOLDER {
+						if isGREASEUint16(vers) {
 							continue
 						}
 						if maxVers < vers || maxVers == 0 {

--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -277,7 +277,7 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, e
 				ks.Group = CurveID(unGREASEUint16(group))
 				// if not GREASE, key share data will be discarded as it should
 				// be generated per connection
-				if ks.Group != GREASE_PLACEHOLDER {
+				if !isGREASEUint16(group) {
 					ks.Data = nil
 				}
 				keyShares = append(keyShares, ks)

--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -324,6 +324,13 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, e
 		case fakeOldExtensionChannelID:
 			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{true})
 
+		case fakeExtensionEncryptThenMAC:
+			if f.AllowBluntMimicry {
+				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
+			} else {
+				return nil, errors.New("unsupported extension Encrypt-then-MAC")
+			}
+
 		case fakeExtensionTokenBinding:
 			var tokenBindingExt FakeTokenBindingExtension
 			var keyParameters cryptobyte.String

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1984,7 +1984,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 	hello.CipherSuites = make([]uint16, len(p.CipherSuites))
 	copy(hello.CipherSuites, p.CipherSuites)
 	for i := range hello.CipherSuites {
-		if hello.CipherSuites[i] == GREASE_PLACEHOLDER {
+		if isGREASEUint16(hello.CipherSuites[i]) {
 			hello.CipherSuites[i] = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_cipher)
 		}
 	}
@@ -2025,7 +2025,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			}
 		case *SupportedCurvesExtension:
 			for i := range ext.Curves {
-				if ext.Curves[i] == GREASE_PLACEHOLDER {
+				if isGREASEUint16(uint16(ext.Curves[i])) {
 					ext.Curves[i] = CurveID(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_group))
 				}
 			}
@@ -2033,7 +2033,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			preferredCurveIsSet := false
 			for i := range ext.KeyShares {
 				curveID := ext.KeyShares[i].Group
-				if curveID == GREASE_PLACEHOLDER {
+				if isGREASEUint16(uint16(curveID)) {
 					ext.KeyShares[i].Group = CurveID(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_group))
 					continue
 				}
@@ -2055,7 +2055,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			}
 		case *SupportedVersionsExtension:
 			for i := range ext.Versions {
-				if ext.Versions[i] == GREASE_PLACEHOLDER {
+				if isGREASEUint16(ext.Versions[i]) {
 					ext.Versions[i] = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_version)
 				}
 			}


### PR DESCRIPTION
This pull request contains two commits:

First, when `AllowBluntMimicry` is set to true, support fake extension: EncryptThenMAC (22) https://datatracker.ietf.org/doc/html/rfc7366

---

Second, properly check if an extension/curve/cipherSuit is GREASE. 

The current version does not properly check GREASE in many cases. In particular, it compares an extension ID, a curve ID, or a cipherSuit against a constant value `GREASE_PLACEHOLDER` `(0x0a0a)`, without unGREASEing it first.

To fix this problem, we simply use the existing function: `isGREASEUint16()` with necessary casting.

For the records, some related error messages prior to this bug fix are:

* "applying generated spec failed: uTLS does not support 0xBABA as max version"
* "applying generated spec failed: unsupported Curve in KeyShareExtension: CurveID(56026).To mimic it, fill the Data(key) field manually"
