### PR TITLE
Bump HelloChrome_Auto version

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -181,7 +181,7 @@ var (
 	HelloFirefox_102  = ClientHelloID{helloFirefox, "102", nil}
 	HelloFirefox_105  = ClientHelloID{helloFirefox, "105", nil}
 
-	HelloChrome_Auto        = HelloChrome_102
+	HelloChrome_Auto        = HelloChrome_106_Shuffle
 	HelloChrome_58          = ClientHelloID{helloChrome, "58", nil}
 	HelloChrome_62          = ClientHelloID{helloChrome, "62", nil}
 	HelloChrome_70          = ClientHelloID{helloChrome, "70", nil}


### PR DESCRIPTION
Use the shuffled Chrome fp `HelloChrome_106_Shuffle` which mimics the latest Chrome's behavior including shuffling the extensions per each `ClientHello` message.

See https://tlsfingerprint.io/norm_fp for more information. 