### PR TITLE
Customable weights used in generateRandomizedSpec()

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -216,6 +216,26 @@ var (
 	HelloQQ_11_1 = ClientHelloID{helloQQ, "11.1", nil}
 )
 
+// Weights used in generateRandomizedSpec(), they should be set in advance.
+var (
+	Weight_Extensions_Append_ALPN                             = 0.7
+	Weight_TLSVersMax_Set_VersionTLS13                        = 0.4
+	Weight_CipherSuites_Remove_RandomCiphers                  = 0.4
+	Weight_SigAndHashAlgos_Append_ECDSAWithSHA1               = 0.63
+	Weight_SigAndHashAlgos_Append_ECDSAWithP521AndSHA512      = 0.59
+	Weight_SigAndHashAlgos_Append_PSSWithSHA256               = 0.51
+	Weight_SigAndHashAlgos_Append_PSSWithSHA384_PSSWithSHA512 = 0.9
+	Weight_CurveIDs_Append_X25519                             = 0.71
+	Weight_CurveIDs_Append_CurveP521                          = 0.46
+	Weight_Extensions_Append_Padding                          = 0.62
+	Weight_Extensions_Append_Status                           = 0.74
+	Weight_Extensions_Append_SCT                              = 0.46
+	Weight_Extensions_Append_Reneg                            = 0.75
+	Weight_Extensions_Append_EMS                              = 0.77
+	Weight_FirstKeyShare_Set_CurveP256                        = 0.25
+	Weight_Extensions_Append_ALPS                             = 0.33
+)
+
 // based on spec's GreaseStyle, GREASE_PLACEHOLDER may be replaced by another GREASE value
 // https://tools.ietf.org/html/draft-ietf-tls-grease-01
 const GREASE_PLACEHOLDER = 0x0a0a

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2107,7 +2107,7 @@ func generateRandomizedSpec(
 	case helloRandomizedNoALPN:
 		WithALPN = false
 	case helloRandomized:
-		if r.FlipWeightedCoin(0.7) {
+		if r.FlipWeightedCoin(Weight_Extensions_Append_ALPN) {
 			WithALPN = true
 		} else {
 			WithALPN = false
@@ -2123,7 +2123,7 @@ func generateRandomizedSpec(
 		return p, err
 	}
 
-	if r.FlipWeightedCoin(0.4) {
+	if r.FlipWeightedCoin(Weight_TLSVersMax_Set_VersionTLS13) {
 		p.TLSVersMin = VersionTLS10
 		p.TLSVersMax = VersionTLS13
 		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13))
@@ -2141,7 +2141,7 @@ func generateRandomizedSpec(
 		p.TLSVersMax = VersionTLS12
 	}
 
-	p.CipherSuites = removeRandomCiphers(r, shuffledSuites, 0.4)
+	p.CipherSuites = removeRandomCiphers(r, shuffledSuites, Weight_CipherSuites_Remove_RandomCiphers)
 
 	sni := SNIExtension{serverName}
 	sessionTicket := SessionTicketExtension{Session: session}
@@ -2155,16 +2155,16 @@ func generateRandomizedSpec(
 		PKCS1WithSHA512,
 	}
 
-	if r.FlipWeightedCoin(0.63) {
+	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_ECDSAWithSHA1) {
 		sigAndHashAlgos = append(sigAndHashAlgos, ECDSAWithSHA1)
 	}
-	if r.FlipWeightedCoin(0.59) {
+	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_ECDSAWithP521AndSHA512) {
 		sigAndHashAlgos = append(sigAndHashAlgos, ECDSAWithP521AndSHA512)
 	}
-	if r.FlipWeightedCoin(0.51) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_PSSWithSHA256) || p.TLSVersMax == VersionTLS13 {
 		// https://tools.ietf.org/html/rfc8446 says "...RSASSA-PSS (which is mandatory in TLS 1.3)..."
 		sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA256)
-		if r.FlipWeightedCoin(0.9) {
+		if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_PSSWithSHA384_PSSWithSHA512) {
 			// these usually go together
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA384)
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA512)
@@ -2182,11 +2182,11 @@ func generateRandomizedSpec(
 	points := SupportedPointsExtension{SupportedPoints: []byte{pointFormatUncompressed}}
 
 	curveIDs := []CurveID{}
-	if r.FlipWeightedCoin(0.71) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(Weight_CurveIDs_Append_X25519) || p.TLSVersMax == VersionTLS13 {
 		curveIDs = append(curveIDs, X25519)
 	}
 	curveIDs = append(curveIDs, CurveP256, CurveP384)
-	if r.FlipWeightedCoin(0.46) {
+	if r.FlipWeightedCoin(Weight_CurveIDs_Append_CurveP521) {
 		curveIDs = append(curveIDs, CurveP521)
 	}
 
@@ -2212,28 +2212,28 @@ func generateRandomizedSpec(
 		p.Extensions = append(p.Extensions, &alpn)
 	}
 
-	if r.FlipWeightedCoin(0.62) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(Weight_Extensions_Append_Padding) || p.TLSVersMax == VersionTLS13 {
 		// always include for TLS 1.3, since TLS 1.3 ClientHellos are often over 256 bytes
 		// and that's when padding is required to work around buggy middleboxes
 		p.Extensions = append(p.Extensions, &padding)
 	}
-	if r.FlipWeightedCoin(0.74) {
+	if r.FlipWeightedCoin(Weight_Extensions_Append_Status) {
 		p.Extensions = append(p.Extensions, &status)
 	}
-	if r.FlipWeightedCoin(0.46) {
+	if r.FlipWeightedCoin(Weight_Extensions_Append_SCT) {
 		p.Extensions = append(p.Extensions, &sct)
 	}
-	if r.FlipWeightedCoin(0.75) {
+	if r.FlipWeightedCoin(Weight_Extensions_Append_Reneg) {
 		p.Extensions = append(p.Extensions, &reneg)
 	}
-	if r.FlipWeightedCoin(0.77) {
+	if r.FlipWeightedCoin(Weight_Extensions_Append_EMS) {
 		p.Extensions = append(p.Extensions, &ems)
 	}
 	if p.TLSVersMax == VersionTLS13 {
 		ks := KeyShareExtension{[]KeyShare{
 			{Group: X25519}, // the key for the group will be generated later
 		}}
-		if r.FlipWeightedCoin(0.25) {
+		if r.FlipWeightedCoin(Weight_FirstKeyShare_Set_CurveP256) {
 			// do not ADD second keyShare because crypto/tls does not support multiple ecdheParams
 			// TODO: add it back when they implement multiple keyShares, or implement it oursevles
 			// ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
@@ -2260,7 +2260,7 @@ func generateRandomizedSpec(
 			if err != nil {
 				return p, err
 			}
-			if r.FlipWeightedCoin(0.33) {
+			if r.FlipWeightedCoin(Weight_Extensions_Append_ALPS) {
 				// As with the ALPN case above, default to something popular
 				// (unlike ALPN, ALPS can't yet be specified in uconn.config).
 				alps := &ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}}

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2087,12 +2087,6 @@ func generateRandomizedSpec(
 ) (ClientHelloSpec, error) {
 	p := ClientHelloSpec{}
 
-	value, ok := WeightsMap.Load(id.Version)
-	if !ok {
-		return p, fmt.Errorf("can not find weights for %v", id.Version)
-	}
-	weights := value.(Weights)
-
 	if id.Seed == nil {
 		seed, err := NewPRNGSeed()
 		if err != nil {
@@ -2105,6 +2099,12 @@ func generateRandomizedSpec(
 	if err != nil {
 		return p, err
 	}
+
+	value, ok := WeightsMap.Load(id.Version)
+	if !ok {
+		return p, fmt.Errorf("failed to load Weights for Version %v from WeightsMap", id.Version)
+	}
+	weights := value.(Weights)
 
 	var WithALPN bool
 	switch id.Client {

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2087,6 +2087,12 @@ func generateRandomizedSpec(
 ) (ClientHelloSpec, error) {
 	p := ClientHelloSpec{}
 
+	value, ok := WeightsMap.Load(id.Version)
+	if !ok {
+		return p, fmt.Errorf("can not find weights for %v", id.Version)
+	}
+	weights := value.(Weights)
+
 	if id.Seed == nil {
 		seed, err := NewPRNGSeed()
 		if err != nil {
@@ -2107,7 +2113,7 @@ func generateRandomizedSpec(
 	case helloRandomizedNoALPN:
 		WithALPN = false
 	case helloRandomized:
-		if r.FlipWeightedCoin(Weight_Extensions_Append_ALPN) {
+		if r.FlipWeightedCoin(weights.Weight_Extensions_Append_ALPN) {
 			WithALPN = true
 		} else {
 			WithALPN = false
@@ -2123,7 +2129,7 @@ func generateRandomizedSpec(
 		return p, err
 	}
 
-	if r.FlipWeightedCoin(Weight_TLSVersMax_Set_VersionTLS13) {
+	if r.FlipWeightedCoin(weights.Weight_TLSVersMax_Set_VersionTLS13) {
 		p.TLSVersMin = VersionTLS10
 		p.TLSVersMax = VersionTLS13
 		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13))
@@ -2141,7 +2147,7 @@ func generateRandomizedSpec(
 		p.TLSVersMax = VersionTLS12
 	}
 
-	p.CipherSuites = removeRandomCiphers(r, shuffledSuites, Weight_CipherSuites_Remove_RandomCiphers)
+	p.CipherSuites = removeRandomCiphers(r, shuffledSuites, weights.Weight_CipherSuites_Remove_RandomCiphers)
 
 	sni := SNIExtension{serverName}
 	sessionTicket := SessionTicketExtension{Session: session}
@@ -2155,16 +2161,16 @@ func generateRandomizedSpec(
 		PKCS1WithSHA512,
 	}
 
-	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_ECDSAWithSHA1) {
+	if r.FlipWeightedCoin(weights.Weight_SigAndHashAlgos_Append_ECDSAWithSHA1) {
 		sigAndHashAlgos = append(sigAndHashAlgos, ECDSAWithSHA1)
 	}
-	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_ECDSAWithP521AndSHA512) {
+	if r.FlipWeightedCoin(weights.Weight_SigAndHashAlgos_Append_ECDSAWithP521AndSHA512) {
 		sigAndHashAlgos = append(sigAndHashAlgos, ECDSAWithP521AndSHA512)
 	}
-	if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_PSSWithSHA256) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(weights.Weight_SigAndHashAlgos_Append_PSSWithSHA256) || p.TLSVersMax == VersionTLS13 {
 		// https://tools.ietf.org/html/rfc8446 says "...RSASSA-PSS (which is mandatory in TLS 1.3)..."
 		sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA256)
-		if r.FlipWeightedCoin(Weight_SigAndHashAlgos_Append_PSSWithSHA384_PSSWithSHA512) {
+		if r.FlipWeightedCoin(weights.Weight_SigAndHashAlgos_Append_PSSWithSHA384_PSSWithSHA512) {
 			// these usually go together
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA384)
 			sigAndHashAlgos = append(sigAndHashAlgos, PSSWithSHA512)
@@ -2182,11 +2188,11 @@ func generateRandomizedSpec(
 	points := SupportedPointsExtension{SupportedPoints: []byte{pointFormatUncompressed}}
 
 	curveIDs := []CurveID{}
-	if r.FlipWeightedCoin(Weight_CurveIDs_Append_X25519) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(weights.Weight_CurveIDs_Append_X25519) || p.TLSVersMax == VersionTLS13 {
 		curveIDs = append(curveIDs, X25519)
 	}
 	curveIDs = append(curveIDs, CurveP256, CurveP384)
-	if r.FlipWeightedCoin(Weight_CurveIDs_Append_CurveP521) {
+	if r.FlipWeightedCoin(weights.Weight_CurveIDs_Append_CurveP521) {
 		curveIDs = append(curveIDs, CurveP521)
 	}
 
@@ -2212,28 +2218,28 @@ func generateRandomizedSpec(
 		p.Extensions = append(p.Extensions, &alpn)
 	}
 
-	if r.FlipWeightedCoin(Weight_Extensions_Append_Padding) || p.TLSVersMax == VersionTLS13 {
+	if r.FlipWeightedCoin(weights.Weight_Extensions_Append_Padding) || p.TLSVersMax == VersionTLS13 {
 		// always include for TLS 1.3, since TLS 1.3 ClientHellos are often over 256 bytes
 		// and that's when padding is required to work around buggy middleboxes
 		p.Extensions = append(p.Extensions, &padding)
 	}
-	if r.FlipWeightedCoin(Weight_Extensions_Append_Status) {
+	if r.FlipWeightedCoin(weights.Weight_Extensions_Append_Status) {
 		p.Extensions = append(p.Extensions, &status)
 	}
-	if r.FlipWeightedCoin(Weight_Extensions_Append_SCT) {
+	if r.FlipWeightedCoin(weights.Weight_Extensions_Append_SCT) {
 		p.Extensions = append(p.Extensions, &sct)
 	}
-	if r.FlipWeightedCoin(Weight_Extensions_Append_Reneg) {
+	if r.FlipWeightedCoin(weights.Weight_Extensions_Append_Reneg) {
 		p.Extensions = append(p.Extensions, &reneg)
 	}
-	if r.FlipWeightedCoin(Weight_Extensions_Append_EMS) {
+	if r.FlipWeightedCoin(weights.Weight_Extensions_Append_EMS) {
 		p.Extensions = append(p.Extensions, &ems)
 	}
 	if p.TLSVersMax == VersionTLS13 {
 		ks := KeyShareExtension{[]KeyShare{
 			{Group: X25519}, // the key for the group will be generated later
 		}}
-		if r.FlipWeightedCoin(Weight_FirstKeyShare_Set_CurveP256) {
+		if r.FlipWeightedCoin(weights.Weight_OnlyKeyShare_Set_CurveP256) {
 			// do not ADD second keyShare because crypto/tls does not support multiple ecdheParams
 			// TODO: add it back when they implement multiple keyShares, or implement it oursevles
 			// ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
@@ -2260,7 +2266,7 @@ func generateRandomizedSpec(
 			if err != nil {
 				return p, err
 			}
-			if r.FlipWeightedCoin(Weight_Extensions_Append_ALPS) {
+			if r.FlipWeightedCoin(weights.Weight_Extensions_Append_ALPS) {
 				// As with the ALPN case above, default to something popular
 				// (unlike ALPN, ALPS can't yet be specified in uconn.config).
 				alps := &ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}}


### PR DESCRIPTION
As described in https://github.com/refraction-networking/utls/pull/157#issuecomment-1417156797, allowing users to set their own weights would be helpful (and convenient for some purposes too).

CC @gaukas 