### PR TITLE
feat: Convert raw bytes or tlsfingerprint record to ClientHelloSpec

### DIFF
--- a/common.go
+++ b/common.go
@@ -151,7 +151,8 @@ const (
 
 // TLS CertificateStatusType (RFC 3546)
 const (
-	statusTypeOCSP uint8 = 1
+	statusTypeOCSP   uint8 = 1
+	statusV2TypeOCSP uint8 = 2
 )
 
 // Certificate types (for certificateRequestMsg)

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -305,7 +305,7 @@ func (m *clientHelloMsg) marshal() []byte {
 }
 
 // marshalWithoutBinders returns the ClientHello through the
-// PreSharedKeyExtension.identities field, according to RFC 8446, Section
+// FakePreSharedKeyExtension.identities field, according to RFC 8446, Section
 // 4.2.11.2. Note that m.pskBinders must be set to slices of the correct length.
 func (m *clientHelloMsg) marshalWithoutBinders() []byte {
 	bindersLen := 2 // uint16 length prefix

--- a/internal/helper/typeconv.go
+++ b/internal/helper/typeconv.go
@@ -1,35 +1,23 @@
 package helper
 
 import (
-	"bytes"
-	"encoding/binary"
-	"io"
-)
+	"errors"
 
-func ReadUint16(r io.Reader, v *uint16) error {
-	var buf [2]byte
-	if _, err := io.ReadFull(r, buf[:]); err != nil {
-		return err
-	}
-	*v = binary.BigEndian.Uint16(buf[:])
-	return nil
-}
+	"golang.org/x/crypto/cryptobyte"
+)
 
 // Uint8to16 converts a slice of uint8 to a slice of uint16.
 // e.g. []uint8{0x00, 0x01, 0x00, 0x02} -> []uint16{0x0001, 0x0002}
 func Uint8to16(in []uint8) ([]uint16, error) {
-	reader := bytes.NewReader(in)
+	s := cryptobyte.String(in)
 	var out []uint16
-	for {
+	for !s.Empty() {
 		var v uint16
-		err := ReadUint16(reader, &v)
-		if err == io.EOF {
-			break
+		if s.ReadUint16(&v) {
+			out = append(out, v)
+		} else {
+			return nil, errors.New("ReadUint16 failed")
 		}
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, v)
 	}
 	return out, nil
 }

--- a/internal/helper/typeconv.go
+++ b/internal/helper/typeconv.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+func ReadUint16(r io.Reader, v *uint16) error {
+	var buf [2]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return err
+	}
+	*v = binary.BigEndian.Uint16(buf[:])
+	return nil
+}
+
+// Uint8to16 converts a slice of uint8 to a slice of uint16.
+// e.g. []uint8{0x00, 0x01, 0x00, 0x02} -> []uint16{0x0001, 0x0002}
+func Uint8to16(in []uint8) ([]uint16, error) {
+	reader := bytes.NewReader(in)
+	var out []uint16
+	for {
+		var v uint16
+		err := ReadUint16(reader, &v)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/u_common.go
+++ b/u_common.go
@@ -198,7 +198,6 @@ func (chs *ClientHelloSpec) ReadTLSExtensions(b []byte, keepPSK, allowBluntMimic
 		if !extensions.ReadUint16LengthPrefixed(&extData) {
 			return fmt.Errorf("unable to read data for extension %x", extension)
 		}
-		log.Printf("extension read: %x, %v", extension, []byte(extData))
 
 		if extension == extensionPreSharedKey && !keepPSK {
 			continue // skip PSK, this will result in fingerprint change!!!!
@@ -359,11 +358,11 @@ func (chs *ClientHelloSpec) ImportTLSClientHello(data map[string][]byte, keepPSK
 				// TODO: tlsfingerprint.io should also provide application settings data
 				extension.(*ApplicationSettingsExtension).SupportedProtocols = []string{"h2"}
 			default:
-				if isGREASEUint16(extType) {
-					log.Printf("[Info] GREASE extension added without specifying Value or Data. It will be automatically re-GREASEd on ApplyPreset() call.")
-				} else {
+				if !isGREASEUint16(extType) {
 					log.Printf("[Warning] extension %d added without data", extType)
-				}
+				} /*else {
+					log.Printf("[Warning] GREASE extension added but ID/Data discarded. They will be automatically re-GREASEd on ApplyPreset() call.")
+				}*/
 			}
 			chs.Extensions = append(chs.Extensions, extension)
 		}

--- a/u_common.go
+++ b/u_common.go
@@ -38,11 +38,12 @@ const (
 	utlsFakeExtensionCustom           uint16 = 1234  // not IANA assigned, for ALPS
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
+	fakeExtensionEncryptThenMAC       uint16 = 22
 	fakeExtensionTokenBinding         uint16 = 24
+	fakeExtensionDelegatedCredentials uint16 = 34
 	fakeExtensionPreSharedKey         uint16 = 41
 	fakeOldExtensionChannelID         uint16 = 30031 // not IANA assigned
 	fakeExtensionChannelID            uint16 = 30032 // not IANA assigned
-	fakeExtensionDelegatedCredentials uint16 = 34
 )
 
 const (

--- a/u_common.go
+++ b/u_common.go
@@ -200,7 +200,8 @@ func (chs *ClientHelloSpec) ReadTLSExtensions(b []byte, keepPSK, allowBluntMimic
 		}
 
 		if extension == extensionPreSharedKey && !keepPSK {
-			continue // skip PSK, this will result in fingerprint change!!!!
+			return fmt.Errorf("PSK extension is not allowed unless keepPSK is set")
+			// continue // skip PSK, this will result in fingerprint change!!!!
 		}
 
 		extWriter := ExtensionIDToExtension(extension)

--- a/u_common.go
+++ b/u_common.go
@@ -39,6 +39,7 @@ const (
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
 	fakeExtensionTokenBinding         uint16 = 24
+	fakeExtensionPreSharedKey         uint16 = 41
 	fakeOldExtensionChannelID         uint16 = 30031 // not IANA assigned
 	fakeExtensionChannelID            uint16 = 30032 // not IANA assigned
 	fakeExtensionDelegatedCredentials uint16 = 34
@@ -233,7 +234,7 @@ func (chs *ClientHelloSpec) AlwaysAddPadding() {
 			alreadyHasPadding = true
 			break
 		}
-		if _, ok := ext.(*PreSharedKeyExtension); ok {
+		if _, ok := ext.(*FakePreSharedKeyExtension); ok {
 			alreadyHasPadding = true // PSK must be last, so we don't need to add padding
 			break
 		}

--- a/u_conn.go
+++ b/u_conn.go
@@ -596,7 +596,7 @@ func (uconn *UConn) SetTLSVers(minTLSVers, maxTLSVers uint16, specExtensions []T
 					minVers := uint16(0)
 					maxVers := uint16(0)
 					for _, vers := range versions {
-						if vers == GREASE_PLACEHOLDER {
+						if isGREASEUint16(vers) {
 							continue
 						}
 						if maxVers < vers || maxVers == 0 {

--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -12,8 +12,6 @@ import (
 
 // Fingerprinter is a struct largely for holding options for the FingerprintClientHello func
 type Fingerprinter struct {
-	// KeepPSK will ensure that the PreSharedKey extension is passed along into the resulting ClientHelloSpec as-is
-	KeepPSK bool
 	// AllowBluntMimicry will ensure that unknown extensions are
 	// passed along into the resulting ClientHelloSpec as-is
 	// It will not ensure that the PSK is passed along, if you require that, use KeepPSK
@@ -103,7 +101,7 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (clientHelloSpec *Cl
 		return nil, errors.New("unable to read extensions data")
 	}
 
-	err = clientHelloSpec.ReadTLSExtensions(extensions, f.KeepPSK, f.AllowBluntMimicry)
+	err = clientHelloSpec.ReadTLSExtensions(extensions, f.AllowBluntMimicry)
 	if err != nil {
 		return nil, err
 	}

--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -84,7 +84,11 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (clientHelloSpec *Cl
 	}
 
 	// CompressionMethods
-	err = clientHelloSpec.ReadCompressionMethods(s)
+	var compressionMethods cryptobyte.String
+	if !s.ReadUint8LengthPrefixed(&compressionMethods) {
+		return nil, errors.New("unable to read compression methods")
+	}
+	err = clientHelloSpec.ReadCompressionMethods(compressionMethods)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +103,10 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (clientHelloSpec *Cl
 		return nil, errors.New("unable to read extensions data")
 	}
 
-	clientHelloSpec.ReadTLSExtensions(extensions, f.KeepPSK, f.AllowBluntMimicry)
+	err = clientHelloSpec.ReadTLSExtensions(extensions, f.KeepPSK, f.AllowBluntMimicry)
+	if err != nil {
+		return nil, err
+	}
 
 	if f.AlwaysAddPadding {
 		clientHelloSpec.AlwaysAddPadding()

--- a/u_fingerprinter.go
+++ b/u_fingerprinter.go
@@ -6,8 +6,6 @@ package tls
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"golang.org/x/crypto/cryptobyte"
 )
@@ -40,8 +38,8 @@ type Fingerprinter struct {
 // as well as the handshake type/length/version header
 // https://tools.ietf.org/html/rfc5246#section-6.2
 // https://tools.ietf.org/html/rfc5246#section-7.4
-func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, error) {
-	clientHelloSpec := &ClientHelloSpec{}
+func (f *Fingerprinter) FingerprintClientHello(data []byte) (clientHelloSpec *ClientHelloSpec, err error) {
+	clientHelloSpec = &ClientHelloSpec{}
 	s := cryptobyte.String(data)
 
 	var contentType uint8
@@ -75,22 +73,20 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, e
 		return nil, errors.New("unable to read session id")
 	}
 
+	// CipherSuites
 	var cipherSuitesBytes cryptobyte.String
 	if !s.ReadUint16LengthPrefixed(&cipherSuitesBytes) {
 		return nil, errors.New("unable to read ciphersuites")
 	}
-	cipherSuites := []uint16{}
-	for !cipherSuitesBytes.Empty() {
-		var suite uint16
-		if !cipherSuitesBytes.ReadUint16(&suite) {
-			return nil, errors.New("unable to read ciphersuite")
-		}
-		cipherSuites = append(cipherSuites, unGREASEUint16(suite))
+	err = clientHelloSpec.ReadCipherSuites(cipherSuitesBytes)
+	if err != nil {
+		return nil, err
 	}
-	clientHelloSpec.CipherSuites = cipherSuites
 
-	if !readUint8LengthPrefixed(&s, &clientHelloSpec.CompressionMethods) {
-		return nil, errors.New("unable to read compression methods")
+	// CompressionMethods
+	err = clientHelloSpec.ReadCompressionMethods(s)
+	if err != nil {
+		return nil, err
 	}
 
 	if s.Empty() {
@@ -103,327 +99,10 @@ func (f *Fingerprinter) FingerprintClientHello(data []byte) (*ClientHelloSpec, e
 		return nil, errors.New("unable to read extensions data")
 	}
 
-	for !extensions.Empty() {
-		var extension uint16
-		var extData cryptobyte.String
-		if !extensions.ReadUint16(&extension) ||
-			!extensions.ReadUint16LengthPrefixed(&extData) {
-			return nil, errors.New("unable to read extension data")
-		}
-
-		switch extension {
-		case extensionServerName:
-			// RFC 6066, Section 3
-			var nameList cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&nameList) || nameList.Empty() {
-				return nil, errors.New("unable to read server name extension data")
-			}
-			var serverName string
-			for !nameList.Empty() {
-				var nameType uint8
-				var serverNameBytes cryptobyte.String
-				if !nameList.ReadUint8(&nameType) ||
-					!nameList.ReadUint16LengthPrefixed(&serverNameBytes) ||
-					serverNameBytes.Empty() {
-					return nil, errors.New("unable to read server name extension data")
-				}
-				if nameType != 0 {
-					continue
-				}
-				if len(serverName) != 0 {
-					return nil, errors.New("multiple names of the same name_type in server name extension are prohibited")
-				}
-				serverName = string(serverNameBytes)
-				if strings.HasSuffix(serverName, ".") {
-					return nil, errors.New("SNI value may not include a trailing dot")
-				}
-
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SNIExtension{})
-
-			}
-		case extensionNextProtoNeg:
-			// draft-agl-tls-nextprotoneg-04
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &NPNExtension{})
-
-		case extensionStatusRequest:
-			// RFC 4366, Section 3.6
-			var statusType uint8
-			var ignored cryptobyte.String
-			if !extData.ReadUint8(&statusType) ||
-				!extData.ReadUint16LengthPrefixed(&ignored) ||
-				!extData.ReadUint16LengthPrefixed(&ignored) {
-				return nil, errors.New("unable to read status request extension data")
-			}
-
-			if statusType == statusTypeOCSP {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &StatusRequestExtension{})
-			} else {
-				return nil, errors.New("status request extension statusType is not statusTypeOCSP")
-			}
-
-		case extensionSupportedCurves:
-			// RFC 4492, sections 5.1.1 and RFC 8446, Section 4.2.7
-			var curvesBytes cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&curvesBytes) || curvesBytes.Empty() {
-				return nil, errors.New("unable to read supported curves extension data")
-			}
-			curves := []CurveID{}
-			for !curvesBytes.Empty() {
-				var curve uint16
-				if !curvesBytes.ReadUint16(&curve) {
-					return nil, errors.New("unable to read supported curves extension data")
-				}
-				curves = append(curves, CurveID(unGREASEUint16(curve)))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SupportedCurvesExtension{curves})
-
-		case extensionSupportedPoints:
-			// RFC 4492, Section 5.1.2
-			supportedPoints := []uint8{}
-			if !readUint8LengthPrefixed(&extData, &supportedPoints) ||
-				len(supportedPoints) == 0 {
-				return nil, errors.New("unable to read supported points extension data")
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SupportedPointsExtension{supportedPoints})
-
-		case extensionSessionTicket:
-			// RFC 5077, Section 3.2
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SessionTicketExtension{})
-
-		case extensionSignatureAlgorithms:
-			// RFC 5246, Section 7.4.1.4.1
-			var sigAndAlgs cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&sigAndAlgs) || sigAndAlgs.Empty() {
-				return nil, errors.New("unable to read signature algorithms extension data")
-			}
-			supportedSignatureAlgorithms := []SignatureScheme{}
-			for !sigAndAlgs.Empty() {
-				var sigAndAlg uint16
-				if !sigAndAlgs.ReadUint16(&sigAndAlg) {
-					return nil, errors.New("unable to read signature algorithms extension data")
-				}
-				supportedSignatureAlgorithms = append(
-					supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SignatureAlgorithmsExtension{supportedSignatureAlgorithms})
-
-		case extensionSignatureAlgorithmsCert:
-			// RFC 8446, Section 4.2.3
-			if f.AllowBluntMimicry {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
-			} else {
-				return nil, errors.New("unsupported extension SignatureAlgorithmsCert")
-			}
-
-		case extensionRenegotiationInfo:
-			// RFC 5746, Section 3.2
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &RenegotiationInfoExtension{RenegotiateOnceAsClient})
-
-		case extensionALPN:
-			// RFC 7301, Section 3.1
-			var protoList cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
-				return nil, errors.New("unable to read ALPN extension data")
-			}
-			alpnProtocols := []string{}
-			for !protoList.Empty() {
-				var proto cryptobyte.String
-				if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
-					return nil, errors.New("unable to read ALPN extension data")
-				}
-				alpnProtocols = append(alpnProtocols, string(proto))
-
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &ALPNExtension{alpnProtocols})
-
-		case extensionSCT:
-			// RFC 6962, Section 3.3.1
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SCTExtension{})
-
-		case extensionSupportedVersions:
-			// RFC 8446, Section 4.2.1
-			var versList cryptobyte.String
-			if !extData.ReadUint8LengthPrefixed(&versList) || versList.Empty() {
-				return nil, errors.New("unable to read supported versions extension data")
-			}
-			supportedVersions := []uint16{}
-			for !versList.Empty() {
-				var vers uint16
-				if !versList.ReadUint16(&vers) {
-					return nil, errors.New("unable to read supported versions extension data")
-				}
-				supportedVersions = append(supportedVersions, unGREASEUint16(vers))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SupportedVersionsExtension{supportedVersions})
-			// If SupportedVersionsExtension is present, use that instead of record+handshake versions
-			clientHelloSpec.TLSVersMin = 0
-			clientHelloSpec.TLSVersMax = 0
-
-		case extensionKeyShare:
-			// RFC 8446, Section 4.2.8
-			var clientShares cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&clientShares) {
-				return nil, errors.New("unable to read key share extension data")
-			}
-			keyShares := []KeyShare{}
-			for !clientShares.Empty() {
-				var ks KeyShare
-				var group uint16
-				if !clientShares.ReadUint16(&group) ||
-					!readUint16LengthPrefixed(&clientShares, &ks.Data) ||
-					len(ks.Data) == 0 {
-					return nil, errors.New("unable to read key share extension data")
-				}
-				ks.Group = CurveID(unGREASEUint16(group))
-				// if not GREASE, key share data will be discarded as it should
-				// be generated per connection
-				if ks.Group != GREASE_PLACEHOLDER {
-					ks.Data = nil
-				}
-				keyShares = append(keyShares, ks)
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &KeyShareExtension{keyShares})
-
-		case extensionPSKModes:
-			// RFC 8446, Section 4.2.9
-			// TODO: PSK Modes have their own form of GREASE-ing which is not currently implemented
-			// the current functionality will NOT re-GREASE/re-randomize these values when using a fingerprinted spec
-			// https://github.com/refraction-networking/utls/pull/58#discussion_r522354105
-			// https://tools.ietf.org/html/draft-ietf-tls-grease-01#section-2
-			pskModes := []uint8{}
-			if !readUint8LengthPrefixed(&extData, &pskModes) {
-				return nil, errors.New("unable to read PSK extension data")
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &PSKKeyExchangeModesExtension{pskModes})
-
-		case utlsExtensionExtendedMasterSecret:
-			// https://tools.ietf.org/html/rfc7627
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsExtendedMasterSecretExtension{})
-
-		case utlsExtensionPadding:
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle})
-
-		case utlsExtensionCompressCertificate:
-			methods := []CertCompressionAlgo{}
-			methodsRaw := new(cryptobyte.String)
-			if !extData.ReadUint8LengthPrefixed(methodsRaw) {
-				return nil, errors.New("unable to read cert compression algorithms extension data")
-			}
-			for !methodsRaw.Empty() {
-				var method uint16
-				if !methodsRaw.ReadUint16(&method) {
-					return nil, errors.New("unable to read cert compression algorithms extension data")
-				}
-				methods = append(methods, CertCompressionAlgo(method))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsCompressCertExtension{methods})
-
-		case fakeExtensionChannelID:
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{})
-
-		case fakeOldExtensionChannelID:
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeChannelIDExtension{true})
-
-		case fakeExtensionTokenBinding:
-			var tokenBindingExt FakeTokenBindingExtension
-			var keyParameters cryptobyte.String
-			if !extData.ReadUint8(&tokenBindingExt.MajorVersion) ||
-				!extData.ReadUint8(&tokenBindingExt.MinorVersion) ||
-				!extData.ReadUint8LengthPrefixed(&keyParameters) {
-				return nil, errors.New("unable to read token binding extension data")
-			}
-			tokenBindingExt.KeyParameters = keyParameters
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &tokenBindingExt)
-
-		case utlsExtensionApplicationSettings:
-			// Similar to ALPN (RFC 7301, Section 3.1):
-			// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps#section-3
-			var protoList cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
-				return nil, errors.New("unable to read ALPS extension data")
-			}
-			supportedProtocols := []string{}
-			for !protoList.Empty() {
-				var proto cryptobyte.String
-				if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
-					return nil, errors.New("unable to read ALPS extension data")
-				}
-				supportedProtocols = append(supportedProtocols, string(proto))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &ApplicationSettingsExtension{supportedProtocols})
-
-		case fakeRecordSizeLimit:
-			recordSizeExt := new(FakeRecordSizeLimitExtension)
-			if !extData.ReadUint16(&recordSizeExt.Limit) {
-				return nil, errors.New("unable to read record size limit extension data")
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, recordSizeExt)
-
-		case fakeExtensionDelegatedCredentials:
-			//https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15#section-4.1.1
-			var supportedAlgs cryptobyte.String
-			if !extData.ReadUint16LengthPrefixed(&supportedAlgs) || supportedAlgs.Empty() {
-				return nil, errors.New("unable to read signature algorithms extension data")
-			}
-			supportedSignatureAlgorithms := []SignatureScheme{}
-			for !supportedAlgs.Empty() {
-				var sigAndAlg uint16
-				if !supportedAlgs.ReadUint16(&sigAndAlg) {
-					return nil, errors.New("unable to read signature algorithms extension data")
-				}
-				supportedSignatureAlgorithms = append(
-					supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
-			}
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &FakeDelegatedCredentialsExtension{supportedSignatureAlgorithms})
-
-		case extensionPreSharedKey:
-			// RFC 8446, Section 4.2.11
-			if f.KeepPSK {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
-			} else {
-				return nil, errors.New("unsupported extension PreSharedKey")
-			}
-
-		case extensionCookie:
-			// RFC 8446, Section 4.2.2
-			if f.AllowBluntMimicry {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
-			} else {
-				return nil, errors.New("unsupported extension Cookie")
-			}
-
-		case extensionEarlyData:
-			// RFC 8446, Section 4.2.10
-			if f.AllowBluntMimicry {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
-			} else {
-				return nil, errors.New("unsupported extension EarlyData")
-			}
-
-		default:
-			if isGREASEUint16(extension) {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsGREASEExtension{unGREASEUint16(extension), extData})
-			} else if f.AllowBluntMimicry {
-				clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &GenericExtension{extension, extData})
-			} else {
-				return nil, fmt.Errorf("unsupported extension %d", extension)
-			}
-
-			continue
-		}
-	}
+	clientHelloSpec.ReadTLSExtensions(extensions, f.KeepPSK, f.AllowBluntMimicry)
 
 	if f.AlwaysAddPadding {
-		alreadyHasPadding := false
-		for _, ext := range clientHelloSpec.Extensions {
-			if _, ok := ext.(*UtlsPaddingExtension); ok {
-				alreadyHasPadding = true
-				break
-			}
-		}
-		if !alreadyHasPadding {
-			clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle})
-		}
+		clientHelloSpec.AlwaysAddPadding()
 	}
 
 	return clientHelloSpec, nil

--- a/u_fingerprinter_test.go
+++ b/u_fingerprinter_test.go
@@ -501,12 +501,6 @@ func TestUTLSFingerprintClientHelloKeepPSK(t *testing.T) {
 	}
 
 	f := &Fingerprinter{}
-	_, err = f.FingerprintClientHello(helloBytes)
-	if err == nil {
-		t.Errorf("expected error generating spec from client hello with PSK")
-	}
-
-	f = &Fingerprinter{KeepPSK: true}
 	generatedSpec, err := f.FingerprintClientHello(helloBytes)
 	if err != nil {
 		t.Errorf("got error: %v; expected to succeed", err)

--- a/u_fingerprinter_test.go
+++ b/u_fingerprinter_test.go
@@ -514,7 +514,7 @@ func TestUTLSFingerprintClientHelloKeepPSK(t *testing.T) {
 	}
 
 	for _, ext := range generatedSpec.Extensions {
-		if _, ok := (ext).(*PreSharedKeyExtension); ok {
+		if _, ok := (ext).(*FakePreSharedKeyExtension); ok {
 			return
 		}
 	}

--- a/u_fingerprinter_test.go
+++ b/u_fingerprinter_test.go
@@ -514,10 +514,8 @@ func TestUTLSFingerprintClientHelloKeepPSK(t *testing.T) {
 	}
 
 	for _, ext := range generatedSpec.Extensions {
-		if genericExtension, ok := (ext).(*GenericExtension); ok {
-			if genericExtension.Id == extensionPreSharedKey {
-				return
-			}
+		if _, ok := (ext).(*PreSharedKeyExtension); ok {
+			return
 		}
 	}
 	t.Errorf("generated ClientHelloSpec with KeepPSK does not include preshared key extension")

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1984,7 +1984,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 	hello.CipherSuites = make([]uint16, len(p.CipherSuites))
 	copy(hello.CipherSuites, p.CipherSuites)
 	for i := range hello.CipherSuites {
-		if hello.CipherSuites[i] == GREASE_PLACEHOLDER {
+		if isGREASEUint16(hello.CipherSuites[i]) { // just in case the user set a GREASE value instead of unGREASEd
 			hello.CipherSuites[i] = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_cipher)
 		}
 	}
@@ -2025,7 +2025,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			}
 		case *SupportedCurvesExtension:
 			for i := range ext.Curves {
-				if ext.Curves[i] == GREASE_PLACEHOLDER {
+				if isGREASEUint16(uint16(ext.Curves[i])) {
 					ext.Curves[i] = CurveID(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_group))
 				}
 			}
@@ -2033,7 +2033,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			preferredCurveIsSet := false
 			for i := range ext.KeyShares {
 				curveID := ext.KeyShares[i].Group
-				if curveID == GREASE_PLACEHOLDER {
+				if isGREASEUint16(uint16(curveID)) { // just in case the user set a GREASE value instead of unGREASEd
 					ext.KeyShares[i].Group = CurveID(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_group))
 					continue
 				}
@@ -2055,7 +2055,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			}
 		case *SupportedVersionsExtension:
 			for i := range ext.Versions {
-				if ext.Versions[i] == GREASE_PLACEHOLDER {
+				if isGREASEUint16(ext.Versions[i]) { // just in case the user set a GREASE value instead of unGREASEd
 					ext.Versions[i] = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_version)
 				}
 			}

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -7,7 +7,78 @@ package tls
 import (
 	"errors"
 	"io"
+	"strings"
+
+	"golang.org/x/crypto/cryptobyte"
 )
+
+// ExtensionIDToExtension returns a TLSExtension for the given extension ID.
+func ExtensionIDToExtension(id uint16) TLSExtensionWriter {
+	// deep copy
+	switch id {
+	case extensionServerName:
+		return &SNIExtension{}
+	case extensionStatusRequest:
+		return &StatusRequestExtension{}
+	case extensionSupportedCurves:
+		return &SupportedCurvesExtension{}
+	case extensionSupportedPoints:
+		return &SupportedPointsExtension{}
+	case extensionSignatureAlgorithms:
+		return &SignatureAlgorithmsExtension{}
+	case extensionALPN:
+		return &ALPNExtension{}
+	case extensionStatusRequestV2:
+		return &StatusRequestV2Extension{}
+	case extensionSCT:
+		return &SCTExtension{}
+	case utlsExtensionPadding:
+		return &UtlsPaddingExtension{}
+	case utlsExtensionExtendedMasterSecret:
+		return &UtlsExtendedMasterSecretExtension{}
+	case fakeExtensionTokenBinding:
+		return &FakeTokenBindingExtension{}
+	case utlsExtensionCompressCertificate:
+		return &UtlsCompressCertExtension{}
+	case fakeExtensionDelegatedCredentials:
+		return &FakeDelegatedCredentialsExtension{}
+	case extensionSessionTicket:
+		return &SessionTicketExtension{}
+	case extensionPreSharedKey:
+		return &PreSharedKeyExtension{}
+	// case extensionEarlyData:
+	// 	return &EarlyDataExtension{}
+	case extensionSupportedVersions:
+		return &SupportedVersionsExtension{}
+	// case extensionCookie:
+	// 	return &CookieExtension{}
+	case extensionPSKModes:
+		return &PSKKeyExchangeModesExtension{}
+	// case extensionCertificateAuthorities:
+	// 	return &CertificateAuthoritiesExtension{}
+	case extensionSignatureAlgorithmsCert:
+		return &SignatureAlgorithmsCertExtension{}
+	case extensionKeyShare:
+		return &KeyShareExtension{}
+	case extensionNextProtoNeg:
+		return &NPNExtension{}
+	case utlsExtensionApplicationSettings:
+		return &ApplicationSettingsExtension{}
+	case fakeOldExtensionChannelID:
+		return &FakeChannelIDExtension{true}
+	case fakeExtensionChannelID:
+		return &FakeChannelIDExtension{}
+	case fakeRecordSizeLimit:
+		return &FakeRecordSizeLimitExtension{}
+	case extensionRenegotiationInfo:
+		return &RenegotiationInfoExtension{}
+	default:
+		if isGREASEUint16(id) {
+			return &UtlsGREASEExtension{}
+		}
+		return nil // not returning GenericExtension, it should be handled by caller
+	}
+}
 
 type TLSExtension interface {
 	writeToUConn(*UConn) error
@@ -17,6 +88,16 @@ type TLSExtension interface {
 	// Read reads up to len(p) bytes into p.
 	// It returns the number of bytes read (0 <= n <= len(p)) and any error encountered.
 	Read(p []byte) (n int, err error) // implements io.Reader
+}
+
+// TLSExtensionWriter is an interface allowing a TLS extension to be
+// auto-constucted/recovered by reading in a byte stream.
+type TLSExtensionWriter interface {
+	TLSExtension
+
+	// Write writes up to len(b) bytes from b.
+	// It returns the number of bytes written (0 <= n <= len(b)) and any error encountered.
+	Write(b []byte) (n int, err error)
 }
 
 type NPNExtension struct {
@@ -41,6 +122,12 @@ func (e *NPNExtension) Read(b []byte) (int, error) {
 	b[1] = byte(extensionNextProtoNeg & 0xff)
 	// The length is always 0
 	return e.Len(), io.EOF
+}
+
+// Write is a no-op for NPNExtension. NextProtos are not included in the
+// ClientHello.
+func (e *NPNExtension) Write(_ []byte) (int, error) {
+	return 0, nil
 }
 
 type SNIExtension struct {
@@ -89,6 +176,42 @@ func (e *SNIExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+// Write is a no-op for StatusRequestExtension.
+// SNI should not be fingerprinted and is user controlled.
+func (e *SNIExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 6066, Section 3
+	var nameList cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&nameList) || nameList.Empty() {
+		return fullLen, errors.New("unable to read server name extension data")
+	}
+	var serverName string
+	for !nameList.Empty() {
+		var nameType uint8
+		var serverNameBytes cryptobyte.String
+		if !nameList.ReadUint8(&nameType) ||
+			!nameList.ReadUint16LengthPrefixed(&serverNameBytes) ||
+			serverNameBytes.Empty() {
+			return fullLen, errors.New("unable to read server name extension data")
+		}
+		if nameType != 0 {
+			continue
+		}
+		if len(serverName) != 0 {
+			return fullLen, errors.New("multiple names of the same name_type in server name extension are prohibited")
+		}
+		serverName = string(serverNameBytes)
+		if strings.HasSuffix(serverName, ".") {
+			return fullLen, errors.New("SNI value may not include a trailing dot")
+		}
+	}
+	// clientHelloSpec.Extensions = append(clientHelloSpec.Extensions, &SNIExtension{}) // gaukas moved this line out from the loop.
+
+	// don't copy SNI from ClientHello to ClientHelloSpec!
+	return fullLen, nil
+}
+
 type StatusRequestExtension struct {
 }
 
@@ -113,6 +236,26 @@ func (e *StatusRequestExtension) Read(b []byte) (int, error) {
 	b[4] = 1 // OCSP type
 	// Two zero valued uint16s for the two lengths.
 	return e.Len(), io.EOF
+}
+
+// Write is a no-op for StatusRequestExtension. No data for this extension.
+func (e *StatusRequestExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 4366, Section 3.6
+	var statusType uint8
+	var ignored cryptobyte.String
+	if !extData.ReadUint8(&statusType) ||
+		!extData.ReadUint16LengthPrefixed(&ignored) ||
+		!extData.ReadUint16LengthPrefixed(&ignored) {
+		return fullLen, errors.New("unable to read status request extension data")
+	}
+
+	if statusType != statusTypeOCSP {
+		return fullLen, errors.New("status request extension statusType is not statusTypeOCSP(1)")
+	}
+
+	return fullLen, nil
 }
 
 type StatusRequestV2Extension struct {
@@ -143,6 +286,28 @@ func (e *StatusRequestV2Extension) Read(b []byte) (int, error) {
 	b[8] = 4
 	// Two zero valued uint16s for the two lengths.
 	return e.Len(), io.EOF
+}
+
+// Write is a no-op for StatusRequestV2Extension. No data for this extension.
+func (e *StatusRequestV2Extension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 4366, Section 3.6
+	var statusType uint8
+	var ignored cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&ignored) ||
+		!extData.ReadUint8(&statusType) ||
+		!extData.ReadUint16LengthPrefixed(&ignored) ||
+		!extData.ReadUint16LengthPrefixed(&ignored) ||
+		!extData.ReadUint16LengthPrefixed(&ignored) {
+		return fullLen, errors.New("unable to read status request v2 extension data")
+	}
+
+	if statusType != statusV2TypeOCSP {
+		return fullLen, errors.New("status request v2 extension statusType is not statusV2TypeOCSP(2)")
+	}
+
+	return fullLen, nil
 }
 
 type SupportedCurvesExtension struct {
@@ -177,6 +342,26 @@ func (e *SupportedCurvesExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *SupportedCurvesExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 4492, sections 5.1.1 and RFC 8446, Section 4.2.7
+	var curvesBytes cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&curvesBytes) || curvesBytes.Empty() {
+		return 0, errors.New("unable to read supported curves extension data")
+	}
+	curves := []CurveID{}
+	for !curvesBytes.Empty() {
+		var curve uint16
+		if !curvesBytes.ReadUint16(&curve) {
+			return 0, errors.New("unable to read supported curves extension data")
+		}
+		curves = append(curves, CurveID(unGREASEUint16(curve)))
+	}
+	e.Curves = curves
+	return fullLen, nil
+}
+
 type SupportedPointsExtension struct {
 	SupportedPoints []uint8
 }
@@ -204,6 +389,19 @@ func (e *SupportedPointsExtension) Read(b []byte) (int, error) {
 		b[5+i] = pointFormat
 	}
 	return e.Len(), io.EOF
+}
+
+func (e *SupportedPointsExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 4492, Section 5.1.2
+	supportedPoints := []uint8{}
+	if !readUint8LengthPrefixed(&extData, &supportedPoints) ||
+		len(supportedPoints) == 0 {
+		return 0, errors.New("unable to read supported points extension data")
+	}
+	e.SupportedPoints = supportedPoints
+	return fullLen, nil
 }
 
 type SignatureAlgorithmsExtension struct {
@@ -237,6 +435,27 @@ func (e *SignatureAlgorithmsExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *SignatureAlgorithmsExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 5246, Section 7.4.1.4.1
+	var sigAndAlgs cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&sigAndAlgs) || sigAndAlgs.Empty() {
+		return 0, errors.New("unable to read signature algorithms extension data")
+	}
+	supportedSignatureAlgorithms := []SignatureScheme{}
+	for !sigAndAlgs.Empty() {
+		var sigAndAlg uint16
+		if !sigAndAlgs.ReadUint16(&sigAndAlg) {
+			return 0, errors.New("unable to read signature algorithms extension data")
+		}
+		supportedSignatureAlgorithms = append(
+			supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
+	}
+	e.SupportedSignatureAlgorithms = supportedSignatureAlgorithms
+	return fullLen, nil
+}
+
 type SignatureAlgorithmsCertExtension struct {
 	SupportedSignatureAlgorithms []SignatureScheme
 }
@@ -266,6 +485,30 @@ func (e *SignatureAlgorithmsCertExtension) Read(b []byte) (int, error) {
 		b[7+2*i] = byte(sigAndHash)
 	}
 	return e.Len(), io.EOF
+}
+
+// Write implementation copied from SignatureAlgorithmsExtension.Write
+//
+// Warning: not tested.
+func (e *SignatureAlgorithmsCertExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 8446, Section 4.2.3
+	var sigAndAlgs cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&sigAndAlgs) || sigAndAlgs.Empty() {
+		return 0, errors.New("unable to read signature algorithms extension data")
+	}
+	supportedSignatureAlgorithms := []SignatureScheme{}
+	for !sigAndAlgs.Empty() {
+		var sigAndAlg uint16
+		if !sigAndAlgs.ReadUint16(&sigAndAlg) {
+			return 0, errors.New("unable to read signature algorithms extension data")
+		}
+		supportedSignatureAlgorithms = append(
+			supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
+	}
+	e.SupportedSignatureAlgorithms = supportedSignatureAlgorithms
+	return fullLen, nil
 }
 
 type RenegotiationInfoExtension struct {
@@ -308,6 +551,11 @@ func (e *RenegotiationInfoExtension) Read(b []byte) (int, error) {
 	copy(b[5:], extInnerBody)
 
 	return e.Len(), io.EOF
+}
+
+func (e *RenegotiationInfoExtension) Write(_ []byte) (int, error) {
+	e.Renegotiation = RenegotiateOnceAsClient
+	return 0, nil
 }
 
 type ALPNExtension struct {
@@ -354,6 +602,27 @@ func (e *ALPNExtension) Read(b []byte) (int, error) {
 	lengths[1] = byte(stringsLength)
 
 	return e.Len(), io.EOF
+}
+
+func (e *ALPNExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 7301, Section 3.1
+	var protoList cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
+		return 0, errors.New("unable to read ALPN extension data")
+	}
+	alpnProtocols := []string{}
+	for !protoList.Empty() {
+		var proto cryptobyte.String
+		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
+			return 0, errors.New("unable to read ALPN extension data")
+		}
+		alpnProtocols = append(alpnProtocols, string(proto))
+
+	}
+	e.AlpnProtocols = alpnProtocols
+	return fullLen, nil
 }
 
 // ApplicationSettingsExtension represents the TLS ALPS extension.
@@ -405,6 +674,28 @@ func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+// Write implementation copied from ALPNExtension.Write
+func (e *ApplicationSettingsExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
+	var protoList cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
+		return 0, errors.New("unable to read ALPN extension data")
+	}
+	alpnProtocols := []string{}
+	for !protoList.Empty() {
+		var proto cryptobyte.String
+		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
+			return 0, errors.New("unable to read ALPN extension data")
+		}
+		alpnProtocols = append(alpnProtocols, string(proto))
+
+	}
+	e.SupportedProtocols = alpnProtocols
+	return fullLen, nil
+}
+
 type SCTExtension struct {
 }
 
@@ -426,6 +717,10 @@ func (e *SCTExtension) Read(b []byte) (int, error) {
 	b[1] = byte(extensionSCT)
 	// zero uint16 for the zero-length extension_data
 	return e.Len(), io.EOF
+}
+
+func (e *SCTExtension) Write(_ []byte) (int, error) {
+	return 0, nil
 }
 
 type SessionTicketExtension struct {
@@ -462,6 +757,11 @@ func (e *SessionTicketExtension) Read(b []byte) (int, error) {
 		copy(b[4:], e.Session.sessionTicket)
 	}
 	return e.Len(), io.EOF
+}
+
+func (e *SessionTicketExtension) Write(_ []byte) (int, error) {
+	// RFC 5077, Section 3.2
+	return 0, nil
 }
 
 // GenericExtension allows to include in ClientHello arbitrary unsupported extensions.
@@ -516,6 +816,11 @@ func (e *UtlsExtendedMasterSecretExtension) Read(b []byte) (int, error) {
 	b[1] = byte(utlsExtensionExtendedMasterSecret)
 	// The length is 0
 	return e.Len(), io.EOF
+}
+
+func (e *UtlsExtendedMasterSecretExtension) Write(_ []byte) (int, error) {
+	// https://tools.ietf.org/html/rfc7627
+	return 0, nil
 }
 
 var extendedMasterSecretLabel = []byte("extended master secret")
@@ -580,6 +885,13 @@ func (e *UtlsGREASEExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *UtlsGREASEExtension) Write(b []byte) (int, error) {
+	e.Value = GREASE_PLACEHOLDER
+	e.Body = make([]byte, len(b))
+	n := copy(e.Body, b)
+	return n, nil
+}
+
 type UtlsPaddingExtension struct {
 	PaddingLen int
 	WillPad    bool // set to false to disable extension
@@ -620,6 +932,25 @@ func (e *UtlsPaddingExtension) Read(b []byte) (int, error) {
 	b[2] = byte(e.PaddingLen >> 8)
 	b[3] = byte(e.PaddingLen)
 	return e.Len(), io.EOF
+}
+
+func (e *UtlsPaddingExtension) Write(_ []byte) (int, error) {
+	e.GetPaddingLen = BoringPaddingStyle
+	return 0, nil
+}
+
+// https://github.com/google/boringssl/blob/7d7554b6b3c79e707e25521e61e066ce2b996e4c/ssl/t1_lib.c#L2803
+func BoringPaddingStyle(unpaddedLen int) (int, bool) {
+	if unpaddedLen > 0xff && unpaddedLen < 0x200 {
+		paddingLen := 0x200 - unpaddedLen
+		if paddingLen >= 4+1 {
+			paddingLen -= 4
+		} else {
+			paddingLen = 1
+		}
+		return paddingLen, true
+	}
+	return 0, false
 }
 
 // UtlsCompressCertExtension is only implemented client-side, for server certificates. Alternate
@@ -667,18 +998,24 @@ func (e *UtlsCompressCertExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
-// https://github.com/google/boringssl/blob/7d7554b6b3c79e707e25521e61e066ce2b996e4c/ssl/t1_lib.c#L2803
-func BoringPaddingStyle(unpaddedLen int) (int, bool) {
-	if unpaddedLen > 0xff && unpaddedLen < 0x200 {
-		paddingLen := 0x200 - unpaddedLen
-		if paddingLen >= 4+1 {
-			paddingLen -= 4
-		} else {
-			paddingLen = 1
-		}
-		return paddingLen, true
+func (e *UtlsCompressCertExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	methods := []CertCompressionAlgo{}
+	methodsRaw := new(cryptobyte.String)
+	if !extData.ReadUint8LengthPrefixed(methodsRaw) {
+		return 0, errors.New("unable to read cert compression algorithms extension data")
 	}
-	return 0, false
+	for !methodsRaw.Empty() {
+		var method uint16
+		if !methodsRaw.ReadUint16(&method) {
+			return 0, errors.New("unable to read cert compression algorithms extension data")
+		}
+		methods = append(methods, CertCompressionAlgo(method))
+	}
+
+	e.Algorithms = methods
+	return fullLen, nil
 }
 
 /* TLS 1.3 */
@@ -724,6 +1061,35 @@ func (e *KeyShareExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *KeyShareExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 8446, Section 4.2.8
+	var clientShares cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&clientShares) {
+		return 0, errors.New("unable to read key share extension data")
+	}
+	keyShares := []KeyShare{}
+	for !clientShares.Empty() {
+		var ks KeyShare
+		var group uint16
+		if !clientShares.ReadUint16(&group) ||
+			!readUint16LengthPrefixed(&clientShares, &ks.Data) ||
+			len(ks.Data) == 0 {
+			return 0, errors.New("unable to read key share extension data")
+		}
+		ks.Group = CurveID(unGREASEUint16(group))
+		// if not GREASE, key share data will be discarded as it should
+		// be generated per connection
+		if ks.Group != GREASE_PLACEHOLDER {
+			ks.Data = nil
+		}
+		keyShares = append(keyShares, ks)
+	}
+	e.KeyShares = keyShares
+	return fullLen, nil
+}
+
 func (e *KeyShareExtension) writeToUConn(uc *UConn) error {
 	uc.HandshakeState.Hello.KeyShares = e.KeyShares
 	return nil
@@ -759,6 +1125,22 @@ func (e *PSKKeyExchangeModesExtension) Read(b []byte) (int, error) {
 	}
 
 	return e.Len(), io.EOF
+}
+
+func (e *PSKKeyExchangeModesExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 8446, Section 4.2.9
+	// TODO: PSK Modes have their own form of GREASE-ing which is not currently implemented
+	// the current functionality will NOT re-GREASE/re-randomize these values when using a fingerprinted spec
+	// https://github.com/refraction-networking/utls/pull/58#discussion_r522354105
+	// https://tools.ietf.org/html/draft-ietf-tls-grease-01#section-2
+	pskModes := []uint8{}
+	if !readUint8LengthPrefixed(&extData, &pskModes) {
+		return 0, errors.New("unable to read PSK extension data")
+	}
+	e.Modes = pskModes
+	return fullLen, nil
 }
 
 func (e *PSKKeyExchangeModesExtension) writeToUConn(uc *UConn) error {
@@ -801,6 +1183,26 @@ func (e *SupportedVersionsExtension) Read(b []byte) (int, error) {
 		i += 2
 	}
 	return e.Len(), io.EOF
+}
+
+func (e *SupportedVersionsExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// RFC 8446, Section 4.2.1
+	var versList cryptobyte.String
+	if !extData.ReadUint8LengthPrefixed(&versList) || versList.Empty() {
+		return 0, errors.New("unable to read supported versions extension data")
+	}
+	supportedVersions := []uint16{}
+	for !versList.Empty() {
+		var vers uint16
+		if !versList.ReadUint16(&vers) {
+			return 0, errors.New("unable to read supported versions extension data")
+		}
+		supportedVersions = append(supportedVersions, unGREASEUint16(vers))
+	}
+	e.Versions = supportedVersions
+	return fullLen, nil
 }
 
 // MUST NOT be part of initial ClientHello
@@ -863,6 +1265,10 @@ func (e *FakeChannelIDExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *FakeChannelIDExtension) Write(_ []byte) (int, error) {
+	return 0, nil
+}
+
 type FakeRecordSizeLimitExtension struct {
 	Limit uint16
 }
@@ -889,6 +1295,15 @@ func (e *FakeRecordSizeLimitExtension) Read(b []byte) (int, error) {
 	b[4] = byte(e.Limit >> 8)
 	b[5] = byte(e.Limit & 0xff)
 	return e.Len(), io.EOF
+}
+
+func (e *FakeRecordSizeLimitExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	if !extData.ReadUint16(&e.Limit) {
+		return 0, errors.New("unable to read record size limit extension data")
+	}
+	return fullLen, nil
 }
 
 type DelegatedCredentialsExtension struct {
@@ -921,7 +1336,6 @@ func (e *DelegatedCredentialsExtension) Read(b []byte) (int, error) {
 }
 
 // https://tools.ietf.org/html/rfc8472#section-2
-
 type FakeTokenBindingExtension struct {
 	MajorVersion, MinorVersion uint8
 	KeyParameters              []uint8
@@ -954,6 +1368,19 @@ func (e *FakeTokenBindingExtension) Read(b []byte) (int, error) {
 	return e.Len(), io.EOF
 }
 
+func (e *FakeTokenBindingExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	var keyParameters cryptobyte.String
+	if !extData.ReadUint8(&e.MajorVersion) ||
+		!extData.ReadUint8(&e.MinorVersion) ||
+		!extData.ReadUint8LengthPrefixed(&keyParameters) {
+		return 0, errors.New("unable to read token binding extension data")
+	}
+	e.KeyParameters = keyParameters
+	return fullLen, nil
+}
+
 // https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15#section-4.1.1
 
 type FakeDelegatedCredentialsExtension struct {
@@ -984,4 +1411,176 @@ func (e *FakeDelegatedCredentialsExtension) Read(b []byte) (int, error) {
 		b[7+2*i] = byte(sigAndHash)
 	}
 	return e.Len(), io.EOF
+}
+
+func (e *FakeDelegatedCredentialsExtension) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	//https://datatracker.ietf.org/doc/html/draft-ietf-tls-subcerts-15#section-4.1.1
+	var supportedAlgs cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&supportedAlgs) || supportedAlgs.Empty() {
+		return 0, errors.New("unable to read signature algorithms extension data")
+	}
+	supportedSignatureAlgorithms := []SignatureScheme{}
+	for !supportedAlgs.Empty() {
+		var sigAndAlg uint16
+		if !supportedAlgs.ReadUint16(&sigAndAlg) {
+			return 0, errors.New("unable to read signature algorithms extension data")
+		}
+		supportedSignatureAlgorithms = append(
+			supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
+	}
+	e.SupportedSignatureAlgorithms = supportedSignatureAlgorithms
+	return fullLen, nil
+}
+
+// PreSharedKeyExtension is an extension used to set the PSK extension in the
+// ClientHello.
+//
+// Warning: detailed test pending. not production ready. Should be treated as
+// a FakeExtension.
+type PreSharedKeyExtension struct {
+	PskIdentities []PskIdentity
+	PskBinders    [][]byte
+}
+
+func (e *PreSharedKeyExtension) writeToUConn(uc *UConn) error {
+	uc.HandshakeState.Hello.PskIdentities = e.PskIdentities
+	uc.HandshakeState.Hello.PskBinders = e.PskBinders
+	return nil
+}
+
+func (e *PreSharedKeyExtension) Len() int {
+	length := 4 // extension type + extension length
+	length += 2 // identities length
+	for _, identity := range e.PskIdentities {
+		length += 2 + len(identity.Label) + 4 // identity length + identity + obfuscated ticket age
+	}
+	length += 2 // binders length
+	for _, binder := range e.PskBinders {
+		length += len(binder)
+	}
+	return length
+}
+
+func (e *PreSharedKeyExtension) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+
+	b[0] = byte(extensionPreSharedKey >> 8)
+	b[1] = byte(extensionPreSharedKey)
+	b[2] = byte((e.Len() - 4) >> 8)
+	b[3] = byte(e.Len() - 4)
+
+	// identities length
+	identitiesLength := 0
+	for _, identity := range e.PskIdentities {
+		identitiesLength += 2 + len(identity.Label) + 4 // identity length + identity + obfuscated ticket age
+	}
+	b[4] = byte(identitiesLength >> 8)
+	b[5] = byte(identitiesLength)
+
+	// identities
+	offset := 6
+	for _, identity := range e.PskIdentities {
+		b[offset] = byte(len(identity.Label) >> 8)
+		b[offset+1] = byte(len(identity.Label))
+		offset += 2
+		copy(b[offset:], identity.Label)
+		offset += len(identity.Label)
+		b[offset] = byte(identity.ObfuscatedTicketAge >> 24)
+		b[offset+1] = byte(identity.ObfuscatedTicketAge >> 16)
+		b[offset+2] = byte(identity.ObfuscatedTicketAge >> 8)
+		b[offset+3] = byte(identity.ObfuscatedTicketAge)
+		offset += 4
+	}
+
+	// binders length
+	bindersLength := 0
+	for _, binder := range e.PskBinders {
+		bindersLength += len(binder)
+	}
+	b[offset] = byte(bindersLength >> 8)
+	b[offset+1] = byte(bindersLength)
+	offset += 2
+
+	// binders
+	for _, binder := range e.PskBinders {
+		copy(b[offset:], binder)
+		offset += len(binder)
+	}
+
+	return e.Len(), io.EOF
+}
+
+func (e *PreSharedKeyExtension) Write(b []byte) (n int, err error) {
+	fullLen := len(b)
+	s := cryptobyte.String(b)
+
+	var identitiesLength uint16
+	if !s.ReadUint16(&identitiesLength) {
+		return 0, errors.New("tls: invalid PSK extension")
+	}
+
+	// identities
+	for identitiesLength > 0 {
+		var identityLength uint16
+		if !s.ReadUint16(&identityLength) {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+		identitiesLength -= 2
+
+		if identityLength > identitiesLength {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+
+		var identity []byte
+		if !s.ReadBytes(&identity, int(identityLength)) {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+
+		identitiesLength -= identityLength // identity
+
+		var obfuscatedTicketAge uint32
+		if !s.ReadUint32(&obfuscatedTicketAge) {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+
+		e.PskIdentities = append(e.PskIdentities, PskIdentity{
+			Label:               identity,
+			ObfuscatedTicketAge: obfuscatedTicketAge,
+		})
+
+		identitiesLength -= 4 // obfuscated ticket age
+	}
+
+	var bindersLength uint16
+	if !s.ReadUint16(&bindersLength) {
+		return 0, errors.New("tls: invalid PSK extension")
+	}
+
+	// binders
+	for bindersLength > 0 {
+		var binderLength uint8
+		if !s.ReadUint8(&binderLength) {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+		bindersLength -= 1
+
+		if uint16(binderLength) > bindersLength {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+
+		var binder []byte
+		if !s.ReadBytes(&binder, int(binderLength)) {
+			return 0, errors.New("tls: invalid PSK extension")
+		}
+
+		e.PskBinders = append(e.PskBinders, binder)
+
+		bindersLength -= uint16(binderLength)
+	}
+
+	return fullLen, nil
 }


### PR DESCRIPTION
Partially implements #164.

- [x] Raw Byte to `ClientHelloSpec` (revisited`Fingerprinter`)
- [x] TLSFingerprint.io parsed ClientHello to `ClientHelloSpec` (see https://client.tlsfingerprint.io/ for example)
- [ ] JSON to `ClientHelloSpec` 
- [ ] Update TLSFingerprint.io 

----

Integrated commits/changes from #148 to prevent merge conflict on #148. Merging this PR should close #148. 