### PR TITLE
crypto/tls: set const maxUselessRecords to 32 (the same with OpenSSL)

### DIFF
--- a/common.go
+++ b/common.go
@@ -42,7 +42,7 @@ const (
 	maxCiphertextTLS13 = 16384 + 256  // maximum ciphertext length in TLS 1.3
 	recordHeaderLen    = 5            // record header length
 	maxHandshake       = 65536        // maximum handshake we support (protocol max is 16 MB)
-	maxUselessRecords  = 16           // maximum number of consecutive non-advancing records
+	maxUselessRecords  = 32           // maximum number of consecutive non-advancing records
 )
 
 // TLS record types.


### PR DESCRIPTION
https://github.com/golang/go/pull/58913