### PR TITLE
Add `InsecureSkipTimeVerify`

### DIFF
--- a/common.go
+++ b/common.go
@@ -656,11 +656,11 @@ type Config struct {
 	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
 	InsecureSkipVerify bool
 
-        // InsecureSkipTimeVerify controls whether a client verifies the server's
-        // certificate chain against time. If InsecureSkipTimeVerify is true, 
-        // crypto/tls accepts the certificate even when it is expired. 
-        //
-        // This field is ignored when InsecureSkipVerify is true.
+	// InsecureSkipTimeVerify controls whether a client verifies the server's
+	// certificate chain against time. If InsecureSkipTimeVerify is true, 
+	// crypto/tls accepts the certificate even when it is expired. 
+	//
+	// This field is ignored when InsecureSkipVerify is true.
 	InsecureSkipTimeVerify bool // [uTLS]
 
 	// InsecureServerNameToVerify is used to verify the hostname on the returned

--- a/common.go
+++ b/common.go
@@ -656,6 +656,14 @@ type Config struct {
 	// testing or in combination with VerifyConnection or VerifyPeerCertificate.
 	InsecureSkipVerify bool
 
+	// InsecureSkipTimeVerify is used to verify the time on the returned
+	// certificates.
+	// If InsecureSkipTimeVerify true, crypto/tls will do normal
+	// certificate validation but ignore certifacate's time.
+	//
+	// This field is ignored when InsecureSkipVerify is true.
+	InsecureSkipTimeVerify bool // [uTLS]
+
 	// InsecureServerNameToVerify is used to verify the hostname on the returned
 	// certificates. It is intended to use with spoofed ServerName.
 	// If InsecureServerNameToVerify is "*", crypto/tls will do normal
@@ -821,6 +829,7 @@ func (c *Config) Clone() *Config {
 		ClientAuth:                  c.ClientAuth,
 		ClientCAs:                   c.ClientCAs,
 		InsecureSkipVerify:          c.InsecureSkipVerify,
+		InsecureSkipTimeVerify:      c.InsecureSkipTimeVerify,
 		InsecureServerNameToVerify:  c.InsecureServerNameToVerify,
 		CipherSuites:                c.CipherSuites,
 		PreferServerCipherSuites:    c.PreferServerCipherSuites,

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -303,6 +303,7 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
 			return cacheKey, nil, nil, nil, nil
 		}
 		serverCert := session.serverCertificates[0]
+		// [UTLS SECTION START]
 		if !c.config.InsecureSkipTimeVerify {
 			if c.config.time().After(serverCert.NotAfter) {
 				// Expired certificate, delete the entry.
@@ -321,6 +322,7 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
 				return cacheKey, nil, nil, nil, nil
 			}
 		}
+		// [UTLS SECTION END]
 	}
 
 	if session.vers != VersionTLS13 {
@@ -901,13 +903,12 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 		// [UTLS SECTION START]
 		opts := x509.VerifyOptions{
 			Roots:         c.config.RootCAs,
+			CurrentTime:   c.config.time(),
 			Intermediates: x509.NewCertPool(),
 		}
 
 		if c.config.InsecureSkipTimeVerify {
 			opts.CurrentTime = certs[0].NotAfter
-		} else {
-			opts.CurrentTime = c.config.time()
 		}
 
 		if len(c.config.InsecureServerNameToVerify) == 0 {

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -310,8 +310,16 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
 				return cacheKey, nil, nil, nil, nil
 			}
 		}
-		if err := serverCert.VerifyHostname(c.config.ServerName); err != nil {
-			return cacheKey, nil, nil, nil, nil
+		var dnsName string
+		if len(c.config.InsecureServerNameToVerify) == 0 {
+			dnsName = c.config.ServerName
+		} else if c.config.InsecureServerNameToVerify != "*" {
+			dnsName = c.config.InsecureServerNameToVerify
+		}
+		if len(dnsName) > 0 {
+			if err := serverCert.VerifyHostname(dnsName); err != nil {
+				return cacheKey, nil, nil, nil, nil
+			}
 		}
 	}
 

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -303,10 +303,12 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
 			return cacheKey, nil, nil, nil, nil
 		}
 		serverCert := session.serverCertificates[0]
-		if c.config.time().After(serverCert.NotAfter) {
-			// Expired certificate, delete the entry.
-			c.config.ClientSessionCache.Put(cacheKey, nil)
-			return cacheKey, nil, nil, nil, nil
+		if !c.config.InsecureSkipTimeVerify {
+			if c.config.time().After(serverCert.NotAfter) {
+				// Expired certificate, delete the entry.
+				c.config.ClientSessionCache.Put(cacheKey, nil)
+				return cacheKey, nil, nil, nil, nil
+			}
 		}
 		if err := serverCert.VerifyHostname(c.config.ServerName); err != nil {
 			return cacheKey, nil, nil, nil, nil
@@ -891,8 +893,13 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 		// [UTLS SECTION START]
 		opts := x509.VerifyOptions{
 			Roots:         c.config.RootCAs,
-			CurrentTime:   c.config.time(),
 			Intermediates: x509.NewCertPool(),
+		}
+
+		if c.config.InsecureSkipTimeVerify {
+			opts.CurrentTime = certs[0].NotAfter
+		} else {
+			opts.CurrentTime = c.config.time()
 		}
 
 		if len(c.config.InsecureServerNameToVerify) == 0 {

--- a/tls_test.go
+++ b/tls_test.go
@@ -814,7 +814,7 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf("b"))
 		case "ClientAuth":
 			f.Set(reflect.ValueOf(VerifyClientCertIfGiven))
-		case "InsecureSkipVerify", "SessionTicketsDisabled", "DynamicRecordSizingDisabled", "PreferServerCipherSuites":
+		case "InsecureSkipVerify", "InsecureSkipTimeVerify", "SessionTicketsDisabled", "DynamicRecordSizingDisabled", "PreferServerCipherSuites":
 			f.Set(reflect.ValueOf(true))
 		case "InsecureServerNameToVerify":
 			f.Set(reflect.ValueOf("c"))


### PR DESCRIPTION
(empty)

----

_Summary added by @gaukas:_

- Added a flag `InsecureSkipTimeVerify` in `Config` to allow skipping client's validation on the `NotAfter` field of server returned certificates against current time. 
- Patched `(*Conn).loadSession()` to also support `config.InsecureServerNameToVerify`, a flag added in a previous commit. 