### PR TITLE
fix: PSK extension w/o session cache crashing

### DIFF
--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -1445,6 +1445,9 @@ type FakePreSharedKeyExtension struct {
 }
 
 func (e *FakePreSharedKeyExtension) writeToUConn(uc *UConn) error {
+	if session, ok := uc.config.ClientSessionCache.Get(clientSessionCacheKey(uc.conn.RemoteAddr(), uc.config)); !ok || session == nil {
+		return nil // don't write the extension if there is no session
+	}
 	uc.HandshakeState.Hello.PskIdentities = e.PskIdentities
 	uc.HandshakeState.Hello.PskBinders = e.PskBinders
 	return nil


### PR DESCRIPTION
Fixes a bug causing client to crash (SIGSEGV) WHEN PSK extension is set with empty session cache AND server sends HelloRetryRequest. 

Crashing is related to:
https://github.com/refraction-networking/utls/blob/6d2506f52f9927498d6d2945884d18ae1e3b72b8/handshake_client_tls13.go#L453 

Where `hs.session` will be nil under certain circumstances. 