### PR TITLE
fix: connection state locked never called

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1551,6 +1551,9 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
+	// [UTLS SECTION START]
+	c.utlsConnectionStateLocked(&state)
+	// [UTLS SECTION END]
 	return state
 }
 


### PR DESCRIPTION
Implication is ALPS peer settings are never copied to the connection state.