### PR TITLE
fix: removed redundant assignment

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2036,9 +2036,7 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 		return errors.New("ClientHello expected length: 32 bytes. Got: " +
 			strconv.Itoa(len(hello.Random)) + " bytes")
 	}
-	if len(hello.CipherSuites) == 0 {
-		hello.CipherSuites = defaultCipherSuites
-	}
+
 	if len(hello.CompressionMethods) == 0 {
 		hello.CompressionMethods = []uint8{compressionNone}
 	}


### PR DESCRIPTION
Removed a legacy assignment to `hello.CipherSuites` in `ApplyPreset()` which gets overwritten later in code. 

Closes #183. 

Thanks @4cq2!