### PR TITLE
fix build error on loongarch64

### DIFF
--- a/cpu/cpu_loong64.go
+++ b/cpu/cpu_loong64.go
@@ -7,7 +7,7 @@
 
 package cpu
 
-const CacheLineSize = 64
+const CacheLinePadSize = 64
 
-func initOptions() {
+func doinit() {
 }


### PR DESCRIPTION
cpu/cpu_loong64.go:10:7: CacheLineSize redeclared in this block
	cpu/cpu.go:20:5: other declaration of CacheLineSize
cpu/cpu.go:15:30: undefined array length CacheLinePadSize or missing type constraint
cpu/cpu.go:20:29: undefined: CacheLinePadSize
cpu/cpu.go:123:2: undefined: doinit