### PR TITLE
Fix support for loong64

### DIFF
--- a/cpu/cpu_loong64.go
+++ b/cpu/cpu_loong64.go
@@ -3,11 +3,11 @@
 // license that can be found in the LICENSE file.
 
 //go:build loong64
-// +build loong64
 
 package cpu
 
-const CacheLineSize = 64
+// CacheLinePadSize is used to prevent false sharing of cache lines.
+// We choose 64 because Loongson 3A5000 the L1 Dcache is 4-way 256-line 64-byte-per-line.
+const CacheLinePadSize = 64
 
-func initOptions() {
-}
+func doinit() {}


### PR DESCRIPTION
This PR fixes the compile error on loong64:

```text
# github.com/refraction-networking/utls/cpu
../../go/pkg/mod/github.com/refraction-networking/utls@v1.2.2-0.20230207151345-a75a4b484849/cpu/cpu_loong64.go:10:7: CacheLineSize redeclared in this block
	../../go/pkg/mod/github.com/refraction-networking/utls@v1.2.2-0.20230207151345-a75a4b484849/cpu/cpu.go:20:5: other declaration of CacheLineSize
../../go/pkg/mod/github.com/refraction-networking/utls@v1.2.2-0.20230207151345-a75a4b484849/cpu/cpu.go:15:30: undeclared name CacheLinePadSize for array length
../../go/pkg/mod/github.com/refraction-networking/utls@v1.2.2-0.20230207151345-a75a4b484849/cpu/cpu.go:20:29: undefined: CacheLinePadSize
../../go/pkg/mod/github.com/refraction-networking/utls@v1.2.2-0.20230207151345-a75a4b484849/cpu/cpu.go:123:2: undefined: doinit
```

This PR fixes the error by simply replacing the current version of `cpu/cpu_loong64` with the current latest version: <https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/internal/cpu/cpu_loong64.go>