### PR TITLE
fix: allow TLS 1.3 as min TLS version

### DIFF
--- a/u_conn.go
+++ b/u_conn.go
@@ -631,7 +631,7 @@ func (uconn *UConn) SetTLSVers(minTLSVers, maxTLSVers uint16, specExtensions []T
 		}
 	}
 
-	if minTLSVers < VersionTLS10 || minTLSVers > VersionTLS12 {
+	if minTLSVers < VersionTLS10 || minTLSVers > VersionTLS13 {
 		return fmt.Errorf("uTLS does not support 0x%X as min version", minTLSVers)
 	}
 


### PR DESCRIPTION
Fixes #191 by allowing `SupportedVersions` extension to support ONLY TLS 1.3 by include no other versions (and therefore enforce TLS 1.3 being negotiated and break 1.2-only servers).