### PR TITLE
workflow: add more version build/test actions

### DIFF
--- a/.github/workflows/go_1_19.yml
+++ b/.github/workflows/go_1_19.yml
@@ -11,15 +11,15 @@ on:
 
 jobs:
 
-  build:
+  go_1.19:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: '1.19'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go_1_20.yml
+++ b/.github/workflows/go_1_20.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  go_1.20:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go_1_21_rc3.yml
+++ b/.github/workflows/go_1_21_rc3.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  go_1.21rc3:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21.0-rc.3'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
- old stable: Go 1.19
- stable: Go 1.20
- beta: Go 1.21rc3

Note that currently we expect tests to fail on Go 1.20 and Go 1.21rc3. Once Go 1.21 becomes stable we will drop Go 1.19

Closes #202. 