### PR TITLE
fix: skip saving to c.config.ClientSessionCache if it is nil

### DIFF
--- a/handshake_client.go
+++ b/handshake_client.go
@@ -941,7 +941,11 @@ func (hs *clientHandshakeState) saveSessionTicket() error {
 	session.secret = hs.masterSecret
 
 	cs := &ClientSessionState{ticket: hs.ticket, session: session}
-	c.config.ClientSessionCache.Put(cacheKey, cs)
+	// [UTLS BEGIN]
+	if c.config.ClientSessionCache != nil { // skip saving session if cache is nil
+		c.config.ClientSessionCache.Put(cacheKey, cs)
+	}
+	// [UTLS END]
 	return nil
 }
 


### PR DESCRIPTION
This is a fix that patches one of the file from upstream (`crypto/tls`), by skipping saving to ClientSessionCache when it is not set in the Config, it allows TLS 1.2 connections to be established while client actively advertises `session_ticket` extension, without modifying configs from previous tagged versions. 

Closes #218.