### PR TITLE
Update Firefox 120 parrot to a more popular version

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1241,6 +1241,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 						0x0, // uncompressed
 					},
 				},
+				&SessionTicketExtension{},
 				&ALPNExtension{
 					AlpnProtocols: []string{
 						"h2",
@@ -1287,6 +1288,9 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 						PKCS1WithSHA1,
 					},
 				},
+				&PSKKeyExchangeModesExtension{[]uint8{
+					PskModeDHE,
+				}},
 				&FakeRecordSizeLimitExtension{
 					Limit: 0x4001,
 				},


### PR DESCRIPTION
Fixes two missing extension from the HelloFirefox_120 parrot:
* An empty `session_ticket (35)`
* `psk_key_exchange_modes (45)` with `psk_dhe_ke` mode.

This is tested with Firefox 120 and Firefox 123.