### PR TITLE
Fixes session ticket / PSK not set

### DIFF
--- a/u_conn.go
+++ b/u_conn.go
@@ -154,9 +154,9 @@ func (uconn *UConn) buildHandshakeState(loadSession bool) error {
 		if loadSession {
 			uconn.uApplyPatch()
 			uconn.sessionController.finalCheck()
+			uconn.clientHelloBuildStatus = BuildByUtls
 		}
 
-		uconn.clientHelloBuildStatus = BuildByUtls
 	}
 	return nil
 }

--- a/u_public.go
+++ b/u_public.go
@@ -676,54 +676,63 @@ func (css *ClientSessionState) VerifiedChains() [][]*x509.Certificate {
 func (css *ClientSessionState) SetSessionTicket(SessionTicket []uint8) {
 	css.ticket = SessionTicket
 }
+
 func (css *ClientSessionState) SetVers(Vers uint16) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.version = Vers
 }
+
 func (css *ClientSessionState) SetCipherSuite(CipherSuite uint16) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.cipherSuite = CipherSuite
 }
+
 func (css *ClientSessionState) SetCreatedAt(createdAt uint64) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.createdAt = createdAt
 }
+
 func (css *ClientSessionState) SetMasterSecret(MasterSecret []byte) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.secret = MasterSecret
 }
+
 func (css *ClientSessionState) SetEMS(ems bool) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.extMasterSecret = ems
 }
+
 func (css *ClientSessionState) SetServerCertificates(ServerCertificates []*x509.Certificate) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.peerCertificates = ServerCertificates
 }
+
 func (css *ClientSessionState) SetVerifiedChains(VerifiedChains [][]*x509.Certificate) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.verifiedChains = VerifiedChains
 }
+
 func (css *ClientSessionState) SetUseBy(useBy uint64) {
 	if css.session == nil {
 		css.session = &SessionState{}
 	}
 	css.session.useBy = useBy
 }
+
 func (css *ClientSessionState) SetAgeAdd(ageAdd uint32) {
 	if css.session == nil {
 		css.session = &SessionState{}

--- a/u_public.go
+++ b/u_public.go
@@ -617,9 +617,6 @@ func (PSS PskIdentities) ToPrivate() []pskIdentity {
 
 // ClientSessionState is public, but all its fields are private. Let's add setters, getters and constructor
 
-// TODO! can we change this enought (or export SessionState),
-// such that we wouldn't need to fork crypto/tls?
-
 // ClientSessionState contains the state needed by clients to resume TLS sessions.
 func MakeClientSessionState(
 	SessionTicket []uint8,

--- a/u_public.go
+++ b/u_public.go
@@ -691,6 +691,12 @@ func (css *ClientSessionState) SetCipherSuite(CipherSuite uint16) {
 	}
 	css.session.cipherSuite = CipherSuite
 }
+func (css *ClientSessionState) SetCreatedAt(createdAt uint64) {
+	if css.session == nil {
+		css.session = &SessionState{}
+	}
+	css.session.createdAt = createdAt
+}
 func (css *ClientSessionState) SetMasterSecret(MasterSecret []byte) {
 	if css.session == nil {
 		css.session = &SessionState{}
@@ -714,6 +720,18 @@ func (css *ClientSessionState) SetVerifiedChains(VerifiedChains [][]*x509.Certif
 		css.session = &SessionState{}
 	}
 	css.session.verifiedChains = VerifiedChains
+}
+func (css *ClientSessionState) SetUseBy(useBy uint64) {
+	if css.session == nil {
+		css.session = &SessionState{}
+	}
+	css.session.useBy = useBy
+}
+func (css *ClientSessionState) SetAgeAdd(ageAdd uint32) {
+	if css.session == nil {
+		css.session = &SessionState{}
+	}
+	css.session.ageAdd = ageAdd
 }
 
 // TicketKey is the internal representation of a session ticket key.


### PR DESCRIPTION
-  Fixes a bug introduced in https://github.com/refraction-networking/utls/pull/301 where `(*sessionController).shouldLoadSession` always returns `shouldReturn`.
- Adds additional setters for ClientSessionState to set fields required to generate an out-of-band PSK.

Review by the uTLS maintainers is much appreciated.