### PR TITLE
fix: generate ClientHelloSpec only once

### DIFF
--- a/u_conn.go
+++ b/u_conn.go
@@ -32,6 +32,7 @@ type UConn struct {
 	sessionController *sessionController
 
 	clientHelloBuildStatus ClientHelloBuildStatus
+	clientHelloSpec        *ClientHelloSpec
 
 	HandshakeState PubClientHandshakeState
 

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2588,25 +2588,32 @@ func ShuffleChromeTLSExtensions(exts []TLSExtension) []TLSExtension {
 }
 
 func (uconn *UConn) applyPresetByID(id ClientHelloID) (err error) {
-	var spec ClientHelloSpec
-	uconn.ClientHelloID = id
-	// choose/generate the spec
-	switch id.Client {
-	case helloRandomized, helloRandomizedNoALPN, helloRandomizedALPN:
-		spec, err = uconn.generateRandomizedSpec()
-		if err != nil {
-			return err
+
+	if uconn.clientHelloSpec == nil {
+
+		var spec ClientHelloSpec
+		uconn.ClientHelloID = id
+
+		// choose/generate the spec
+		switch id.Client {
+		case helloRandomized, helloRandomizedNoALPN, helloRandomizedALPN:
+			spec, err = uconn.generateRandomizedSpec()
+			if err != nil {
+				return err
+			}
+		case helloCustom:
+			return nil
+		default:
+			spec, err = UTLSIdToSpec(id)
+			if err != nil {
+				return err
+			}
 		}
-	case helloCustom:
-		return nil
-	default:
-		spec, err = UTLSIdToSpec(id)
-		if err != nil {
-			return err
-		}
+
+		uconn.clientHelloSpec = &spec
 	}
 
-	return uconn.ApplyPreset(&spec)
+	return uconn.ApplyPreset(uconn.clientHelloSpec)
 }
 
 // ApplyPreset should only be used in conjunction with HelloCustom to apply custom specs.


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/refraction-networking/utls/pull/301 where calling `BuildHanshakeStateWithoutSession` with a random profile, generates a new `CilentHelloSpec` on each call.

This PR assume that `UConn.ClientHelloID` is read-only and that it's value should not be modified, which is my understanding of uTLS currently operates. If this assumption is false, another workaround needs to be found.

A review of this is very much appreciated.