### PR TITLE
fix: extMasterSecret mismatch with extended_master_secret extension

### DIFF
--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -219,7 +219,6 @@ func (c *Conn) makeClientHelloForApplyPreset() (*clientHelloMsg, clientKeyShareP
 		vers:                         clientHelloVersion,
 		compressionMethods:           []uint8{compressionNone},
 		random:                       make([]byte, 32),
-		extendedMasterSecret:         true,
 		ocspStapling:                 true,
 		scts:                         true,
 		serverName:                   hostnameInSNI(config.ServerName),


### PR DESCRIPTION
Fixes an issue where `clientHelloMsg.extendedMasterSecret`/`PubClientHelloMsg.Ems` is always true, even if the extended_master_secret extension is not set in the Client Hello (e.g. from a random TLS profile).