### PR TITLE
feat: add support for ECH when using custom clienthello specs

### DIFF
--- a/ech.go
+++ b/ech.go
@@ -207,8 +207,16 @@ func pickECHCipherSuite(suites []echCipher) (echCipher, error) {
 	return echCipher{}, errors.New("tls: no supported symmetric ciphersuites for ECH")
 }
 
+// [uTLS SECTION BEGIN]
 func encodeInnerClientHello(inner *clientHelloMsg, maxNameLength int) ([]byte, error) {
-	h, err := inner.marshalMsg(true)
+	return encodeInnerClientHelloReorderOuterExts(inner, maxNameLength, nil)
+}
+
+// [uTLS SECTION END]
+
+// func encodeInnerClientHello(inner *clientHelloMsg, maxNameLength int) ([]byte, error) {
+func encodeInnerClientHelloReorderOuterExts(inner *clientHelloMsg, maxNameLength int, outerExts []uint16) ([]byte, error) { // uTLS
+	h, err := inner.marshalMsgReorderOuterExts(true, outerExts)
 	if err != nil {
 		return nil, err
 	}

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -214,9 +214,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
 
 	var ech *echClientContext
 	if c.config.EncryptedClientHelloConfigList != nil {
-		if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
-			return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
-		}
+		// if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
+		// 	return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
+		// }
 		if c.config.MaxVersion != 0 && c.config.MaxVersion <= VersionTLS12 {
 			return nil, nil, nil, errors.New("tls: MaxVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
 		}

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -214,9 +214,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *keySharePrivateKeys, *echCli
 
 	var ech *echClientContext
 	if c.config.EncryptedClientHelloConfigList != nil {
-		// if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
-		// 	return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
-		// }
+		if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
+			return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
+		}
 		if c.config.MaxVersion != 0 && c.config.MaxVersion <= VersionTLS12 {
 			return nil, nil, nil, errors.New("tls: MaxVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
 		}

--- a/handshake_test.go
+++ b/handshake_test.go
@@ -476,11 +476,32 @@ func runMain(m *testing.M) int {
 }
 
 func testHandshake(t *testing.T, clientConfig, serverConfig *Config) (serverState, clientState ConnectionState, err error) {
+	// [uTLS SECTION BEGIN]
+	return testUtlsHandshake(t, clientConfig, serverConfig, nil)
+}
+func testUtlsHandshake(t *testing.T, clientConfig, serverConfig *Config, spec *ClientHelloSpec) (serverState, clientState ConnectionState, err error) {
+	// [uTLS SECTION END]
 	const sentinel = "SENTINEL\n"
 	c, s := localPipe(t)
 	errChan := make(chan error, 1)
 	go func() {
-		cli := Client(c, clientConfig)
+		// [uTLS SECTION BEGIN]
+		var cli interface {
+			Handshake() error
+			ConnectionState() ConnectionState
+			Close() error
+			io.Reader
+		}
+		if spec != nil {
+			ucli := UClient(c, clientConfig, HelloCustom)
+			if err = ucli.ApplyPreset(spec); err != nil {
+				return
+			}
+			cli = ucli
+		} else {
+			cli = Client(c, clientConfig)
+		}
+		// [uTLS SECTION END]
 		err := cli.Handshake()
 		if err != nil {
 			errChan <- fmt.Errorf("client: %v", err)

--- a/u_conn_test.go
+++ b/u_conn_test.go
@@ -743,3 +743,111 @@ func TestUTLSMakeConnWithCompleteHandshake(t *testing.T) {
 
 	serverTls.Write(serverMsg)
 }
+
+func TestUTLSECH(t *testing.T) {
+	chromeLatest, err := utlsIdToSpec(HelloChrome_Auto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firefoxLatest, err := utlsIdToSpec(HelloFirefox_Auto)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name          string
+		spec          *ClientHelloSpec
+		expectSuccess bool
+	}{
+		{
+			name:          "latest chrome",
+			spec:          &chromeLatest,
+			expectSuccess: true,
+		},
+		{
+			name:          "latest firefox",
+			spec:          &firefoxLatest,
+			expectSuccess: true,
+		},
+		{
+			name: "ech extension missing",
+			spec: &ClientHelloSpec{
+				CipherSuites: []uint16{
+					GREASE_PLACEHOLDER,
+					TLS_AES_128_GCM_SHA256,
+					TLS_AES_256_GCM_SHA384,
+					TLS_CHACHA20_POLY1305_SHA256,
+					TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+					TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+					TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					TLS_RSA_WITH_AES_128_GCM_SHA256,
+					TLS_RSA_WITH_AES_256_GCM_SHA384,
+					TLS_RSA_WITH_AES_128_CBC_SHA,
+					TLS_RSA_WITH_AES_256_CBC_SHA,
+				},
+				CompressionMethods: []byte{
+					0x00, // compressionNone
+				},
+				Extensions: ShuffleChromeTLSExtensions([]TLSExtension{
+					&UtlsGREASEExtension{},
+					&SNIExtension{},
+					&ExtendedMasterSecretExtension{},
+					&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient},
+					&SupportedCurvesExtension{[]CurveID{
+						GREASE_PLACEHOLDER,
+						X25519Kyber768Draft00,
+						X25519,
+						CurveP256,
+						CurveP384,
+					}},
+					&SupportedPointsExtension{SupportedPoints: []byte{
+						0x00, // pointFormatUncompressed
+					}},
+					&SessionTicketExtension{},
+					&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}},
+					&StatusRequestExtension{},
+					&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{
+						ECDSAWithP256AndSHA256,
+						PSSWithSHA256,
+						PKCS1WithSHA256,
+						ECDSAWithP384AndSHA384,
+						PSSWithSHA384,
+						PKCS1WithSHA384,
+						PSSWithSHA512,
+						PKCS1WithSHA512,
+					}},
+					&SCTExtension{},
+					&KeyShareExtension{[]KeyShare{
+						{Group: CurveID(GREASE_PLACEHOLDER), Data: []byte{0}},
+						{Group: X25519Kyber768Draft00},
+						{Group: X25519},
+					}},
+					&PSKKeyExchangeModesExtension{[]uint8{
+						PskModeDHE,
+					}},
+					&SupportedVersionsExtension{[]uint16{
+						GREASE_PLACEHOLDER,
+						VersionTLS13,
+						VersionTLS12,
+					}},
+					&UtlsCompressCertExtension{[]CertCompressionAlgo{
+						CertCompressionBrotli,
+					}},
+					&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
+					&UtlsGREASEExtension{},
+				}),
+			},
+			expectSuccess: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testECHSpec(t, test.spec, test.expectSuccess)
+		})
+	}
+}

--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -353,9 +353,9 @@ func (c *Conn) makeClientHelloForApplyPreset() (*clientHelloMsg, *keySharePrivat
 
 	var ech *echClientContext
 	if c.config.EncryptedClientHelloConfigList != nil {
-		if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
-			return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
-		}
+		// if c.config.MinVersion != 0 && c.config.MinVersion < VersionTLS13 {
+		// 	return nil, nil, nil, errors.New("tls: MinVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
+		// }
 		if c.config.MaxVersion != 0 && c.config.MaxVersion <= VersionTLS12 {
 			return nil, nil, nil, errors.New("tls: MaxVersion must be >= VersionTLS13 if EncryptedClientHelloConfigList is populated")
 		}
@@ -483,7 +483,7 @@ func (c *UConn) clientHandshake(ctx context.Context) (err error) {
 		}()
 	}
 
-	if ech != nil {
+	if ech != nil && c.clientHelloBuildStatus == BuildByGoTLS {
 		// Split hello into inner and outer
 		ech.innerHello = hello.clone()
 


### PR DESCRIPTION
This PR enables ECH when the user provides a ClientHello spec that has an extension implementing the `EncryptedClientHelloExtension` interface (such as the `GREASEEncryptedClientHelloExtension` currently for all the browsers) and follows the standard library’s ECH API of providing the `EncryptedClientHelloConfigList` in the config. 

When ECH is enabled, we generate another ClientHello as the ClientHelloInner using the standard library’s handshake marshaling functions and encode it in our ClientHelloOuter. Some extensions are substituted in the OuterExtensions list, in which case the uTLS generated values in the ClientHelloOuter will be used. We reorder the OuterExtensions list according to the structure in the outer ClientHello spec. 