### PR TITLE
Implement Chrome 133+ support

### DIFF
--- a/dicttls/exttype_values.go
+++ b/dicttls/exttype_values.go
@@ -69,6 +69,7 @@ const (
 const (
 	ExtType_next_protocol_negotiation uint16 = 13172 // https://datatracker.ietf.org/doc/html/draft-agl-tls-nextprotoneg-04
 	ExtType_application_settings      uint16 = 17513 // https://www.ietf.org/archive/id/draft-vvv-tls-alps-01.html
+	ExtType_application_settings_new  uint16 = 17613 // https://www.ietf.org/archive/id/draft-vvv-tls-alps-01.html
 	ExtType_channel_id_old            uint16 = 30031 // https://datatracker.ietf.org/doc/html/draft-balfanz-tls-channelid-01
 	ExtType_channel_id                uint16 = 30032 // https://datatracker.ietf.org/doc/html/draft-balfanz-tls-channelid-01
 )
@@ -136,6 +137,7 @@ var DictExtTypeValueIndexed = map[uint16]string{
 
 	13172: "next_protocol_negotiation",
 	17513: "application_settings",
+	17613: "application_settings_new",
 	30031: "channel_id_old",
 	30032: "channel_id",
 }
@@ -204,6 +206,7 @@ var DictExtTypeNameIndexed = map[string]uint16{
 
 	"next_protocol_negotiation": 13172,
 	"application_settings":      17513,
+	"application_settings_new":  17613,
 	"channel_id_old":            30031,
 	"channel_id":                30032,
 }

--- a/u_common.go
+++ b/u_common.go
@@ -34,12 +34,13 @@ const (
 const (
 	extensionNextProtoNeg uint16 = 13172 // not IANA assigned. Removed by crypto/tls since Nov 2019
 
-	utlsExtensionPadding             uint16 = 21
-	utlsExtensionCompressCertificate uint16 = 27     // https://datatracker.ietf.org/doc/html/rfc8879#section-7.1
-	utlsExtensionApplicationSettings uint16 = 17513  // not IANA assigned
-	utlsFakeExtensionCustom          uint16 = 1234   // not IANA assigned, for ALPS
-	utlsExtensionECH                 uint16 = 0xfe0d // draft-ietf-tls-esni-17
-	utlsExtensionECHOuterExtensions  uint16 = 0xfd00 // draft-ietf-tls-esni-17
+	utlsExtensionPadding                uint16 = 21
+	utlsExtensionCompressCertificate    uint16 = 27     // https://datatracker.ietf.org/doc/html/rfc8879#section-7.1
+	utlsExtensionApplicationSettings    uint16 = 17513  // not IANA assigned
+	utlsExtensionApplicationSettingsNew uint16 = 17613  // not IANA assigned
+	utlsFakeExtensionCustom             uint16 = 1234   // not IANA assigned, for ALPS
+	utlsExtensionECH                    uint16 = 0xfe0d // draft-ietf-tls-esni-17
+	utlsExtensionECHOuterExtensions     uint16 = 0xfd00 // draft-ietf-tls-esni-17
 
 	// extensions with 'fake' prefix break connection, if server echoes them back
 	fakeExtensionEncryptThenMAC       uint16 = 22
@@ -447,6 +448,8 @@ func (chs *ClientHelloSpec) ImportTLSClientHello(data map[string][]byte) error {
 			case utlsExtensionApplicationSettings:
 				// TODO: tlsfingerprint.io should record/provide application settings data
 				extWriter.(*ApplicationSettingsExtension).SupportedProtocols = []string{"h2"}
+			case utlsExtensionApplicationSettingsNew:
+				extWriter.(*ApplicationSettingsExtensionNew).SupportedProtocols = []string{"h2"}
 			case extensionPreSharedKey:
 				log.Printf("[Warning] PSK extension added without data")
 			default:

--- a/u_common.go
+++ b/u_common.go
@@ -609,7 +609,7 @@ var (
 	HelloFirefox_105  = ClientHelloID{helloFirefox, "105", nil, nil}
 	HelloFirefox_120  = ClientHelloID{helloFirefox, "120", nil, nil}
 
-	HelloChrome_Auto        = HelloChrome_131
+	HelloChrome_Auto        = HelloChrome_133
 	HelloChrome_58          = ClientHelloID{helloChrome, "58", nil, nil}
 	HelloChrome_62          = ClientHelloID{helloChrome, "62", nil, nil}
 	HelloChrome_70          = ClientHelloID{helloChrome, "70", nil, nil}
@@ -639,6 +639,8 @@ var (
 	HelloChrome_120_PQ = ClientHelloID{helloChrome, "120_PQ", nil, nil}
 	// Chrome w/ ML-KEM curve
 	HelloChrome_131 = ClientHelloID{helloChrome, "131", nil, nil}
+	// Chrome w/ New ALPS codepoint
+	HelloChrome_133 = ClientHelloID{helloChrome, "133", nil, nil}
 
 	HelloIOS_Auto = HelloIOS_14
 	HelloIOS_11_1 = ClientHelloID{helloIOS, "111", nil, nil} // legacy "111" means 11.1

--- a/u_conn.go
+++ b/u_conn.go
@@ -846,9 +846,9 @@ func (c *Conn) utlsConnectionStateLocked(state *ConnectionState) {
 
 type utlsConnExtraFields struct {
 	// Application Settings (ALPS)
-	hasApplicationSettings   bool
-	peerApplicationSettings  []byte
-	localApplicationSettings []byte
+	peerApplicationSettings      []byte
+	localApplicationSettings     []byte
+	applicationSettingsCodepoint uint16
 
 	// Encrypted Client Hello (ECH)
 	echRetryConfigs []ECHConfig

--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -131,8 +131,8 @@ func (hs *clientHandshakeStateTLS13) serverFinishedReceived() error {
 func (hs *clientHandshakeStateTLS13) sendClientEncryptedExtensions() error {
 	c := hs.c
 	clientEncryptedExtensions := new(utlsClientEncryptedExtensionsMsg)
-	if c.utls.hasApplicationSettings {
-		clientEncryptedExtensions.hasApplicationSettings = true
+	if c.utls.applicationSettingsCodepoint != 0 {
+		clientEncryptedExtensions.applicationSettingsCodepoint = c.utls.applicationSettingsCodepoint
 		clientEncryptedExtensions.applicationSettings = c.utls.localApplicationSettings
 		if _, err := c.writeHandshakeRecord(clientEncryptedExtensions, hs.transcript); err != nil {
 			return err
@@ -143,11 +143,11 @@ func (hs *clientHandshakeStateTLS13) sendClientEncryptedExtensions() error {
 }
 
 func (hs *clientHandshakeStateTLS13) utlsReadServerParameters(encryptedExtensions *encryptedExtensionsMsg) error {
-	hs.c.utls.hasApplicationSettings = encryptedExtensions.utls.hasApplicationSettings
 	hs.c.utls.peerApplicationSettings = encryptedExtensions.utls.applicationSettings
+	hs.c.utls.applicationSettingsCodepoint = encryptedExtensions.utls.applicationSettingsCodepoint
 	hs.c.utls.echRetryConfigs = encryptedExtensions.utls.echRetryConfigs
 
-	if hs.c.utls.hasApplicationSettings {
+	if hs.c.utls.applicationSettingsCodepoint != 0 {
 		if hs.uconn.vers < VersionTLS13 {
 			return errors.New("tls: server sent application settings at invalid version")
 		}

--- a/u_handshake_messages.go
+++ b/u_handshake_messages.go
@@ -54,16 +54,18 @@ func (m *utlsCompressedCertificateMsg) unmarshal(data []byte) bool {
 }
 
 type utlsEncryptedExtensionsMsgExtraFields struct {
-	hasApplicationSettings bool
-	applicationSettings    []byte
-	echRetryConfigs        []ECHConfig
-	customExtension        []byte
+	applicationSettings          []byte
+	applicationSettingsCodepoint uint16
+	echRetryConfigs              []ECHConfig
+	customExtension              []byte
 }
 
 func (m *encryptedExtensionsMsg) utlsUnmarshal(extension uint16, extData cryptobyte.String) bool {
 	switch extension {
 	case utlsExtensionApplicationSettings:
-		m.utls.hasApplicationSettings = true
+		fallthrough
+	case utlsExtensionApplicationSettingsNew:
+		m.utls.applicationSettingsCodepoint = extension
 		m.utls.applicationSettings = []byte(extData)
 	case utlsExtensionECH:
 		var err error
@@ -76,10 +78,10 @@ func (m *encryptedExtensionsMsg) utlsUnmarshal(extension uint16, extData cryptob
 }
 
 type utlsClientEncryptedExtensionsMsg struct {
-	raw                    []byte
-	applicationSettings    []byte
-	hasApplicationSettings bool
-	customExtension        []byte
+	raw                          []byte
+	applicationSettings          []byte
+	applicationSettingsCodepoint uint16
+	customExtension              []byte
 }
 
 func (m *utlsClientEncryptedExtensionsMsg) marshal() (x []byte, err error) {
@@ -91,8 +93,8 @@ func (m *utlsClientEncryptedExtensionsMsg) marshal() (x []byte, err error) {
 	builder.AddUint8(typeEncryptedExtensions)
 	builder.AddUint24LengthPrefixed(func(body *cryptobyte.Builder) {
 		body.AddUint16LengthPrefixed(func(extensions *cryptobyte.Builder) {
-			if m.hasApplicationSettings {
-				extensions.AddUint16(utlsExtensionApplicationSettings)
+			if m.applicationSettingsCodepoint != 0 {
+				extensions.AddUint16(m.applicationSettingsCodepoint)
 				extensions.AddUint16LengthPrefixed(func(msg *cryptobyte.Builder) {
 					msg.AddBytes(m.applicationSettings)
 				})
@@ -130,7 +132,9 @@ func (m *utlsClientEncryptedExtensionsMsg) unmarshal(data []byte) bool {
 
 		switch extension {
 		case utlsExtensionApplicationSettings:
-			m.hasApplicationSettings = true
+			fallthrough
+		case utlsExtensionApplicationSettingsNew:
+			m.applicationSettingsCodepoint = extension
 			m.applicationSettings = []byte(extData)
 		default:
 			// Unknown extensions are illegal in EncryptedExtensions.

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -880,6 +880,80 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&UtlsGREASEExtension{},
 			}),
 		}, nil
+	case HelloChrome_133:
+		return ClientHelloSpec{
+			CipherSuites: []uint16{
+				GREASE_PLACEHOLDER,
+				TLS_AES_128_GCM_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				0x00, // compressionNone
+			},
+			Extensions: ShuffleChromeTLSExtensions([]TLSExtension{
+				&UtlsGREASEExtension{},
+				&SNIExtension{},
+				&ExtendedMasterSecretExtension{},
+				&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient},
+				&SupportedCurvesExtension{[]CurveID{
+					GREASE_PLACEHOLDER,
+					X25519MLKEM768,
+					X25519,
+					CurveP256,
+					CurveP384,
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{
+					0x00, // pointFormatUncompressed
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}},
+				&StatusRequestExtension{},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{
+					ECDSAWithP256AndSHA256,
+					PSSWithSHA256,
+					PKCS1WithSHA256,
+					ECDSAWithP384AndSHA384,
+					PSSWithSHA384,
+					PKCS1WithSHA384,
+					PSSWithSHA512,
+					PKCS1WithSHA512,
+				}},
+				&SCTExtension{},
+				&KeyShareExtension{[]KeyShare{
+					{Group: CurveID(GREASE_PLACEHOLDER), Data: []byte{0}},
+					{Group: X25519MLKEM768},
+					{Group: X25519},
+				}},
+				&PSKKeyExchangeModesExtension{[]uint8{
+					PskModeDHE,
+				}},
+				&SupportedVersionsExtension{[]uint16{
+					GREASE_PLACEHOLDER,
+					VersionTLS13,
+					VersionTLS12,
+				}},
+				&UtlsCompressCertExtension{[]CertCompressionAlgo{
+					CertCompressionBrotli,
+				}},
+				&ApplicationSettingsExtensionNew{&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}}},
+				// &ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
+				BoringGREASEECH(),
+				&UtlsGREASEExtension{},
+			}),
+		}, nil
 	case HelloFirefox_55, HelloFirefox_56:
 		return ClientHelloSpec{
 			TLSVersMax: VersionTLS12,

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -948,8 +948,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&UtlsCompressCertExtension{[]CertCompressionAlgo{
 					CertCompressionBrotli,
 				}},
-				&ApplicationSettingsExtensionNew{&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}}},
-				// &ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
+				&ApplicationSettingsExtensionNew{SupportedProtocols: []string{"h2"}},
 				BoringGREASEECH(),
 				&UtlsGREASEExtension{},
 			}),

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -768,6 +768,86 @@ func (e *ApplicationSettingsExtension) Write(b []byte) (int, error) {
 	return fullLen, nil
 }
 
+// ApplicationSettingsExtensionNew represents the TLS ALPS codepoint extension introduced by Chrome 133.
+// More information can be found here: https://chromestatus.com/feature/5149147365900288
+// TODO: This probably should be implemented differently
+type ApplicationSettingsExtensionNew struct {
+	*ApplicationSettingsExtension
+}
+
+func (e *ApplicationSettingsExtensionNew) Len() int {
+	bLen := 2 + 2 + 2 // Type + Length + ALPS Extension length
+	for _, s := range e.SupportedProtocols {
+		bLen += 1 + len(s) // Supported ALPN Length + actual length of protocol
+	}
+	return bLen
+}
+
+func (e *ApplicationSettingsExtensionNew) Read(b []byte) (int, error) {
+	if len(b) < e.Len() {
+		return 0, io.ErrShortBuffer
+	}
+
+	// Read Type.
+	b[0] = byte(17613 >> 8)   // hex: 44 dec: 68
+	b[1] = byte(17613 & 0xff) // hex: 69 dec: 105
+
+	lengths := b[2:] // get the remaining buffer without Type
+	b = b[6:]        // set the buffer to the buffer without Type, Length and ALPS Extension Length (so only the Supported ALPN list remains)
+
+	stringsLength := 0
+	for _, s := range e.SupportedProtocols {
+		l := len(s)            // Supported ALPN Length
+		b[0] = byte(l)         // Supported ALPN Length in bytes hex: 02 dec: 2
+		copy(b[1:], s)         // copy the Supported ALPN as bytes to the buffer
+		b = b[1+l:]            // set the buffer to the buffer without the Supported ALPN Length and Supported ALPN (so we can continue to the next protocol in this loop)
+		stringsLength += 1 + l // Supported ALPN Length (the field itself) + Supported ALPN Length (the value)
+	}
+
+	lengths[2] = byte(stringsLength >> 8) // ALPS Extension Length hex: 00 dec: 0
+	lengths[3] = byte(stringsLength)      // ALPS Extension Length hex: 03 dec: 3
+	stringsLength += 2                    // plus ALPS Extension Length field length
+	lengths[0] = byte(stringsLength >> 8) // Length hex:00 dec: 0
+	lengths[1] = byte(stringsLength)      // Length hex: 05 dec: 5
+
+	return e.Len(), io.EOF
+}
+
+func (e *ApplicationSettingsExtensionNew) UnmarshalJSON(b []byte) error {
+	var applicationSettingsSupport struct {
+		SupportedProtocols []string `json:"supported_protocols_new"`
+	}
+
+	if err := json.Unmarshal(b, &applicationSettingsSupport); err != nil {
+		return err
+	}
+
+	e.SupportedProtocols = applicationSettingsSupport.SupportedProtocols
+	return nil
+}
+
+// Write implementation copied from ALPNExtension.Write
+func (e *ApplicationSettingsExtensionNew) Write(b []byte) (int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
+	var protoList cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
+		return 0, errors.New("unable to read ALPN extension data")
+	}
+	alpnProtocols := []string{}
+	for !protoList.Empty() {
+		var proto cryptobyte.String
+		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
+			return 0, errors.New("unable to read ALPN extension data")
+		}
+		alpnProtocols = append(alpnProtocols, string(proto))
+
+	}
+	e.SupportedProtocols = alpnProtocols
+	return fullLen, nil
+}
+
 // SCTExtension implements signed_certificate_timestamp (18)
 type SCTExtension struct {
 }

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -71,6 +71,8 @@ func ExtensionFromID(id uint16) TLSExtension {
 		return &NPNExtension{}
 	case utlsExtensionApplicationSettings:
 		return &ApplicationSettingsExtension{}
+	case utlsExtensionApplicationSettingsNew:
+		return &ApplicationSettingsExtensionNew{}
 	case fakeOldExtensionChannelID:
 		return &FakeChannelIDExtension{true}
 	case fakeExtensionChannelID:
@@ -684,39 +686,39 @@ func (e *ALPNExtension) Write(b []byte) (int, error) {
 	return fullLen, nil
 }
 
-// ApplicationSettingsExtension represents the TLS ALPS extension.
+// applicationSettingsExtension represents the TLS ALPS extension.
 // At the time of this writing, this extension is currently a draft:
 // https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
-type ApplicationSettingsExtension struct {
-	SupportedProtocols []string
+type applicationSettingsExtension struct {
+	codePoint uint16
 }
 
-func (e *ApplicationSettingsExtension) writeToUConn(uc *UConn) error {
+func (e *applicationSettingsExtension) writeToUConn(uc *UConn) error {
 	return nil
 }
 
-func (e *ApplicationSettingsExtension) Len() int {
+func (e *applicationSettingsExtension) Len(supportedProtocols []string) int {
 	bLen := 2 + 2 + 2 // Type + Length + ALPS Extension length
-	for _, s := range e.SupportedProtocols {
+	for _, s := range supportedProtocols {
 		bLen += 1 + len(s) // Supported ALPN Length + actual length of protocol
 	}
 	return bLen
 }
 
-func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
-	if len(b) < e.Len() {
+func (e *applicationSettingsExtension) Read(b []byte, supportedProtocols []string) (int, error) {
+	if len(b) < e.Len(supportedProtocols) {
 		return 0, io.ErrShortBuffer
 	}
 
 	// Read Type.
-	b[0] = byte(utlsExtensionApplicationSettings >> 8)   // hex: 44 dec: 68
-	b[1] = byte(utlsExtensionApplicationSettings & 0xff) // hex: 69 dec: 105
+	b[0] = byte(e.codePoint >> 8)   // hex: 44 dec: 68
+	b[1] = byte(e.codePoint & 0xff) // hex: 69 dec: 105
 
 	lengths := b[2:] // get the remaining buffer without Type
 	b = b[6:]        // set the buffer to the buffer without Type, Length and ALPS Extension Length (so only the Supported ALPN list remains)
 
 	stringsLength := 0
-	for _, s := range e.SupportedProtocols {
+	for _, s := range supportedProtocols {
 		l := len(s)            // Supported ALPN Length
 		b[0] = byte(l)         // Supported ALPN Length in bytes hex: 02 dec: 2
 		copy(b[1:], s)         // copy the Supported ALPN as bytes to the buffer
@@ -730,7 +732,43 @@ func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
 	lengths[0] = byte(stringsLength >> 8) // Length hex:00 dec: 0
 	lengths[1] = byte(stringsLength)      // Length hex: 05 dec: 5
 
-	return e.Len(), io.EOF
+	return e.Len(supportedProtocols), io.EOF
+}
+
+// Write implementation copied from ALPNExtension.Write
+func (e *applicationSettingsExtension) Write(b []byte) ([]string, int, error) {
+	fullLen := len(b)
+	extData := cryptobyte.String(b)
+	// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
+	var protoList cryptobyte.String
+	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
+		return nil, 0, errors.New("unable to read ALPN extension data")
+	}
+	alpnProtocols := []string{}
+	for !protoList.Empty() {
+		var proto cryptobyte.String
+		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
+			return nil, 0, errors.New("unable to read ALPN extension data")
+		}
+		alpnProtocols = append(alpnProtocols, string(proto))
+
+	}
+	return alpnProtocols, fullLen, nil
+}
+
+// ApplicationSettingsExtension embeds applicationSettingsExtension to implement the TLS ALPS extension on codepoint 17513
+type ApplicationSettingsExtension struct {
+	applicationSettingsExtension
+	SupportedProtocols []string
+}
+
+func (e *ApplicationSettingsExtension) Len() int {
+	return e.applicationSettingsExtension.Len(e.SupportedProtocols)
+}
+
+func (e *ApplicationSettingsExtension) Read(b []byte) (int, error) {
+	e.applicationSettingsExtension.codePoint = utlsExtensionApplicationSettings
+	return e.applicationSettingsExtension.Read(b, e.SupportedProtocols)
 }
 
 func (e *ApplicationSettingsExtension) UnmarshalJSON(b []byte) error {
@@ -748,74 +786,33 @@ func (e *ApplicationSettingsExtension) UnmarshalJSON(b []byte) error {
 
 // Write implementation copied from ALPNExtension.Write
 func (e *ApplicationSettingsExtension) Write(b []byte) (int, error) {
-	fullLen := len(b)
-	extData := cryptobyte.String(b)
-	// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
-	var protoList cryptobyte.String
-	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
-		return 0, errors.New("unable to read ALPN extension data")
-	}
-	alpnProtocols := []string{}
-	for !protoList.Empty() {
-		var proto cryptobyte.String
-		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
-			return 0, errors.New("unable to read ALPN extension data")
-		}
-		alpnProtocols = append(alpnProtocols, string(proto))
-
-	}
-	e.SupportedProtocols = alpnProtocols
-	return fullLen, nil
+	var (
+		fullLen int
+		err     error
+	)
+	e.SupportedProtocols, fullLen, err = e.applicationSettingsExtension.Write(b)
+	return fullLen, err
 }
 
-// ApplicationSettingsExtensionNew represents the TLS ALPS codepoint extension introduced by Chrome 133.
+// ApplicationSettingsExtensionNew embeds applicationSettingsExtension to implement the TLS ALPS extension on codepoint 17613
 // More information can be found here: https://chromestatus.com/feature/5149147365900288
-// TODO: This probably should be implemented differently
 type ApplicationSettingsExtensionNew struct {
-	*ApplicationSettingsExtension
+	applicationSettingsExtension
+	SupportedProtocols []string
 }
 
 func (e *ApplicationSettingsExtensionNew) Len() int {
-	bLen := 2 + 2 + 2 // Type + Length + ALPS Extension length
-	for _, s := range e.SupportedProtocols {
-		bLen += 1 + len(s) // Supported ALPN Length + actual length of protocol
-	}
-	return bLen
+	return e.applicationSettingsExtension.Len(e.SupportedProtocols)
 }
 
 func (e *ApplicationSettingsExtensionNew) Read(b []byte) (int, error) {
-	if len(b) < e.Len() {
-		return 0, io.ErrShortBuffer
-	}
-
-	// Read Type.
-	b[0] = byte(17613 >> 8)   // hex: 44 dec: 68
-	b[1] = byte(17613 & 0xff) // hex: 69 dec: 105
-
-	lengths := b[2:] // get the remaining buffer without Type
-	b = b[6:]        // set the buffer to the buffer without Type, Length and ALPS Extension Length (so only the Supported ALPN list remains)
-
-	stringsLength := 0
-	for _, s := range e.SupportedProtocols {
-		l := len(s)            // Supported ALPN Length
-		b[0] = byte(l)         // Supported ALPN Length in bytes hex: 02 dec: 2
-		copy(b[1:], s)         // copy the Supported ALPN as bytes to the buffer
-		b = b[1+l:]            // set the buffer to the buffer without the Supported ALPN Length and Supported ALPN (so we can continue to the next protocol in this loop)
-		stringsLength += 1 + l // Supported ALPN Length (the field itself) + Supported ALPN Length (the value)
-	}
-
-	lengths[2] = byte(stringsLength >> 8) // ALPS Extension Length hex: 00 dec: 0
-	lengths[3] = byte(stringsLength)      // ALPS Extension Length hex: 03 dec: 3
-	stringsLength += 2                    // plus ALPS Extension Length field length
-	lengths[0] = byte(stringsLength >> 8) // Length hex:00 dec: 0
-	lengths[1] = byte(stringsLength)      // Length hex: 05 dec: 5
-
-	return e.Len(), io.EOF
+	e.applicationSettingsExtension.codePoint = utlsExtensionApplicationSettingsNew
+	return e.applicationSettingsExtension.Read(b, e.SupportedProtocols)
 }
 
 func (e *ApplicationSettingsExtensionNew) UnmarshalJSON(b []byte) error {
 	var applicationSettingsSupport struct {
-		SupportedProtocols []string `json:"supported_protocols_new"`
+		SupportedProtocols []string `json:"supported_protocols"`
 	}
 
 	if err := json.Unmarshal(b, &applicationSettingsSupport); err != nil {
@@ -828,24 +825,12 @@ func (e *ApplicationSettingsExtensionNew) UnmarshalJSON(b []byte) error {
 
 // Write implementation copied from ALPNExtension.Write
 func (e *ApplicationSettingsExtensionNew) Write(b []byte) (int, error) {
-	fullLen := len(b)
-	extData := cryptobyte.String(b)
-	// https://datatracker.ietf.org/doc/html/draft-vvv-tls-alps-01
-	var protoList cryptobyte.String
-	if !extData.ReadUint16LengthPrefixed(&protoList) || protoList.Empty() {
-		return 0, errors.New("unable to read ALPN extension data")
-	}
-	alpnProtocols := []string{}
-	for !protoList.Empty() {
-		var proto cryptobyte.String
-		if !protoList.ReadUint8LengthPrefixed(&proto) || proto.Empty() {
-			return 0, errors.New("unable to read ALPN extension data")
-		}
-		alpnProtocols = append(alpnProtocols, string(proto))
-
-	}
-	e.SupportedProtocols = alpnProtocols
-	return fullLen, nil
+	var (
+		fullLen int
+		err     error
+	)
+	e.SupportedProtocols, fullLen, err = e.applicationSettingsExtension.Write(b)
+	return fullLen, err
 }
 
 // SCTExtension implements signed_certificate_timestamp (18)


### PR DESCRIPTION
Since Chrome 133 the TLS fingerprint is changing due to this feature:
https://chromestatus.com/feature/5149147365900288

I found that others are also running into this problem here: https://github.com/refraction-networking/utls/issues/330

It looks like a "full" implementation might be bigger than just extending the current application settings extension, as per another implementation here:
https://github.com/bogdanfinn/utls/commit/fe91add3ecedd324b1b3b395c7b8bc0f72f224da

Opening this PR as a draft to discuss how we should move forward on this, I've also implemented [this](https://github.com/refraction-networking/utls/issues/330#issuecomment-2743313690) for the time being as it might be enough to address this (at least for my use case) 