### PR TITLE
Fix check for TLS downgrade canary

### DIFF
--- a/handshake_test.go
+++ b/handshake_test.go
@@ -477,7 +477,7 @@ func runMain(m *testing.M) int {
 
 func testHandshake(t *testing.T, clientConfig, serverConfig *Config) (serverState, clientState ConnectionState, err error) {
 	// [uTLS SECTION BEGIN]
-	return testUtlsHandshake(t, clientConfig, serverConfig, nil)
+	return testUtlsHandshake(t, clientConfig, serverConfig, spec)
 }
 func testUtlsHandshake(t *testing.T, clientConfig, serverConfig *Config, spec *ClientHelloSpec) (serverState, clientState ConnectionState, err error) {
 	// [uTLS SECTION END]

--- a/u_public.go
+++ b/u_public.go
@@ -894,6 +894,9 @@ type KeySharePrivateKeys struct {
 }
 
 func (ksp *KeySharePrivateKeys) ToPrivate() *keySharePrivateKeys {
+	if ksp == nil {
+		return nil
+	}
 	return &keySharePrivateKeys{
 		curveID: ksp.CurveID,
 		ecdhe:   ksp.Ecdhe,
@@ -902,6 +905,9 @@ func (ksp *KeySharePrivateKeys) ToPrivate() *keySharePrivateKeys {
 }
 
 func (ksp *keySharePrivateKeys) ToPublic() *KeySharePrivateKeys {
+	if ksp == nil {
+		return nil
+	}
 	return &KeySharePrivateKeys{
 		CurveID: ksp.curveID,
 		Ecdhe:   ksp.ecdhe,


### PR DESCRIPTION
Add TLS downgrade protection code from stdlib to `uconn.clientHandshake`. Also fix a related nil pointer dereference bug. 

Closes #181