### PR TITLE
fix: prevent copying outer server name in inner

### DIFF
--- a/u_conn.go
+++ b/u_conn.go
@@ -579,18 +579,6 @@ func (uconn *UConn) MarshalClientHello() error {
 
 		ech.innerHello = inner
 
-		sniExtIdex := slices.IndexFunc(uconn.Extensions, func(ext TLSExtension) bool {
-			_, ok := ext.(*SNIExtension)
-			return ok
-		})
-		if sniExtIdex < 0 {
-			return fmt.Errorf("sni extension missing while attempting ECH")
-		}
-
-		uconn.Extensions[sniExtIdex] = &SNIExtension{
-			ServerName: string(ech.config.PublicName),
-		}
-
 		uconn.computeAndUpdateOuterECHExtension(inner, ech, true)
 
 		uconn.echCtx = ech

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2779,6 +2779,9 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 			if ext.ServerName == "" {
 				ext.ServerName = uconn.config.ServerName
 			}
+			if uconn.config.EncryptedClientHelloConfigList != nil {
+				ext.ServerName = string(ech.config.PublicName)
+			}
 		case *UtlsGREASEExtension:
 			switch grease_extensions_seen {
 			case 0:

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -197,7 +197,9 @@ func (e *SNIExtension) Write(b []byte) (int, error) {
 }
 
 func (e *SNIExtension) writeToUConn(uc *UConn) error {
-	uc.config.ServerName = e.ServerName
+	if uc.config.EncryptedClientHelloConfigList == nil { // with ech, e.ServerName is the outer public name and should not be copied
+		uc.config.ServerName = e.ServerName
+	}
 	hostName := hostnameInSNI(e.ServerName)
 	uc.HandshakeState.Hello.ServerName = hostName
 


### PR DESCRIPTION
Update ECH outer SNI during ApplyPreset instead of Marshal so that it is not copied multiple times. Do not override server name in config when ECH is enabled.

Fixes #340 