### PR TITLE
[Cleaner Version] Support for Certificate Compression Algorithm extension in Certificate Request Message

### DIFF
--- a/common.go
+++ b/common.go
@@ -116,6 +116,7 @@ const (
 	extensionStatusRequestV2         uint16 = 17
 	extensionSCT                     uint16 = 18
 	extensionExtendedMasterSecret    uint16 = 23
+	extensionCompressCertificate     uint16 = 27
 	extensionDelegatedCredentials    uint16 = 34
 	extensionSessionTicket           uint16 = 35
 	extensionPreSharedKey            uint16 = 41

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -1280,6 +1280,7 @@ type certificateRequestMsgTLS13 struct {
 	scts                             bool
 	supportedSignatureAlgorithms     []SignatureScheme
 	supportedSignatureAlgorithmsCert []SignatureScheme
+	certRequestCompressionAlgs       []CertCompressionAlgo
 	certificateAuthorities           [][]byte
 }
 
@@ -1315,6 +1316,17 @@ func (m *certificateRequestMsgTLS13) marshal() ([]byte, error) {
 					})
 				})
 			}
+			if len(m.certRequestCompressionAlgs) > 0 {
+				b.AddUint16(extensionCompressCertificate)
+				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+					b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+						for _, algo := range m.certRequestCompressionAlgs {
+							b.AddUint16(uint16(algo))
+						}
+					})
+				})
+			}
+
 			if len(m.supportedSignatureAlgorithmsCert) > 0 {
 				b.AddUint16(extensionSignatureAlgorithmsCert)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
@@ -1380,6 +1392,19 @@ func (m *certificateRequestMsgTLS13) unmarshal(data []byte) bool {
 				}
 				m.supportedSignatureAlgorithms = append(
 					m.supportedSignatureAlgorithms, SignatureScheme(sigAndAlg))
+			}
+		case extensionCompressCertificate:
+			var algs cryptobyte.String
+			if !extData.ReadUint8LengthPrefixed(&algs) || algs.Empty() {
+				return false
+			}
+			for !algs.Empty() {
+				var alg uint16
+				if !algs.ReadUint16(&alg) {
+					return false
+				}
+				m.certRequestCompressionAlgs = append(
+					m.certRequestCompressionAlgs, CertCompressionAlgo(alg))
 			}
 		case extensionSignatureAlgorithmsCert:
 			var sigAndAlgs cryptobyte.String


### PR DESCRIPTION
Intended to do the same functionality as my previous pr #347  but for a cleaner commit history. Hence the following description is copied from previous pr.

---

This version introduces a new CertCompressionAlgo implementation for certificateRequestMsgTLS13 in handshake_messages.go, addressing issue https://github.com/refraction-networking/utls/issues/345.

The change resolves the error: 'tls: invalid signature by the server certificate: crypto/rsa: verification error'
which occurs when connecting to servers that include a certificate compression algorithm extension in the CertificateRequest message during the TLS 1.3 handshake.

@BRUHItsABunny — would you mind testing this on your end to confirm the fix works as expected?