### PR TITLE
Add entropy in generateRandomizedSpec()

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -684,6 +684,7 @@ type Weights struct {
 	Extensions_Append_Reneg                            float64
 	Extensions_Append_EMS                              float64
 	FirstKeyShare_Set_CurveP256                        float64
+	KeyShare_Append_RandomGroups                       float64
 	Extensions_Append_ALPS                             float64
 }
 
@@ -704,7 +705,8 @@ var DefaultWeights = Weights{
 	Extensions_Append_SCT:                              0.46,
 	Extensions_Append_Reneg:                            0.75,
 	Extensions_Append_EMS:                              0.77,
-	FirstKeyShare_Set_CurveP256:                        0.25,
+	FirstKeyShare_Set_CurveP256:                        0.00, // legacy setting
+	KeyShare_Append_RandomGroups:                       0.50,
 	Extensions_Append_ALPS:                             0.33,
 }
 

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2927,9 +2927,7 @@ func generateRandomizedSpec(
 	}
 
 	if r.FlipWeightedCoin(id.Weights.TLSVersMax_Set_VersionTLS13) {
-		// randomize min TLS version
-		minTLSVersCandidates := []uint16{VersionTLS10, VersionTLS12}
-		p.TLSVersMin = minTLSVersCandidates[r.Intn(len(minTLSVersCandidates))]
+		p.TLSVersMin = VersionTLS12
 		p.TLSVersMax = VersionTLS13
 		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13))
 		copy(tls13ciphers, defaultCipherSuitesTLS13)

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -3054,6 +3054,9 @@ func generateRandomizedSpec(
 	points := SupportedPointsExtension{SupportedPoints: []byte{pointFormatUncompressed}}
 
 	curveIDs := []CurveID{}
+	if r.FlipWeightedCoin(id.Weights.CurveIDs_Append_X25519) && p.TLSVersMax == VersionTLS13 {
+		curveIDs = append(curveIDs, X25519MLKEM768)
+	}
 	if r.FlipWeightedCoin(id.Weights.CurveIDs_Append_X25519) || p.TLSVersMax == VersionTLS13 {
 		curveIDs = append(curveIDs, X25519)
 	}
@@ -3105,11 +3108,15 @@ func generateRandomizedSpec(
 		ks := KeyShareExtension{[]KeyShare{
 			{Group: X25519}, // the key for the group will be generated later
 		}}
-		if r.FlipWeightedCoin(id.Weights.FirstKeyShare_Set_CurveP256) {
-			// do not ADD second keyShare because crypto/tls does not support multiple ecdheParams
-			// TODO: add it back when they implement multiple keyShares, or implement it oursevles
-			// ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
+		if r.FlipWeightedCoin(id.Weights.FirstKeyShare_Set_CurveP256) { // legacy setting, not used by default
 			ks.KeyShares[0].Group = CurveP256
+		} else {
+			if r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups) {
+				ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
+			}
+			if r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups) {
+				ks.KeyShares = append([]KeyShare{{Group: X25519MLKEM768}}, ks.KeyShares...)
+			}
 		}
 		pskExchangeModes := PSKKeyExchangeModesExtension{[]uint8{pskModeDHE}}
 		supportedVersionsExt := SupportedVersionsExtension{

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2927,7 +2927,7 @@ func generateRandomizedSpec(
 	}
 
 	if r.FlipWeightedCoin(id.Weights.TLSVersMax_Set_VersionTLS13) {
-		p.TLSVersMin = VersionTLS10
+		p.TLSVersMin = VersionTLS12
 		p.TLSVersMax = VersionTLS13
 		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13))
 		copy(tls13ciphers, defaultCipherSuitesTLS13)

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2927,7 +2927,9 @@ func generateRandomizedSpec(
 	}
 
 	if r.FlipWeightedCoin(id.Weights.TLSVersMax_Set_VersionTLS13) {
-		p.TLSVersMin = VersionTLS12
+		// randomize min TLS version
+		minTLSVersCandidates := []uint16{VersionTLS10, VersionTLS12}
+		p.TLSVersMin = minTLSVersCandidates[r.Intn(len(minTLSVersCandidates))]
 		p.TLSVersMax = VersionTLS13
 		tls13ciphers := make([]uint16, len(defaultCipherSuitesTLS13))
 		copy(tls13ciphers, defaultCipherSuitesTLS13)


### PR DESCRIPTION
- random min TLS version (1.0 or 1.2) when max TLS version is 1.3
- add X25519MLKEM768 to curveIDs controlled by id.Weights.CurveIDs_Append_X25519 for TLS1.3
- randomized keyShare groups with X25519MLKEM768 controlled by a new id.Weights.KeyShare_Append_RandomGroups 
- id.Weights.FirstKeyShare_Set_CurveP256 set to legacy, 0.0