### PR TITLE
Expose `serverHello` earlier in clientHandshake()

### DIFF
--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -568,6 +568,7 @@ func (c *UConn) clientHandshake(ctx context.Context) (err error) {
 			hs13.session = session
 		}
 		hs13.ctx = ctx
+		c.HandshakeState.ServerHello = serverHello.getPublicPtr()
 		// In TLS 1.3, session tickets are delivered after the handshake.
 		err = hs13.handshake()
 		if handshakeState := hs13.toPublic13(); handshakeState != nil {


### PR DESCRIPTION
For https://github.com/XTLS/REALITY/commit/69793c864044ae04455c3e4aac9925c0650d990, I need to visit `serverHello` in VerifyPeerCertificate()