### PR TITLE
Expose `serverHello` earlier in clientHandshake()

### DIFF
--- a/u_handshake_client.go
+++ b/u_handshake_client.go
@@ -551,6 +551,7 @@ func (c *UConn) clientHandshake(ctx context.Context) (err error) {
 	}
 
 	// uTLS: do not create new handshakeState, use existing one
+	c.HandshakeState.ServerHello = serverHello.getPublicPtr()
 	if c.vers == VersionTLS13 {
 		hs13 := c.HandshakeState.toPrivate13()
 		hs13.serverHello = serverHello


### PR DESCRIPTION
Re-apply https://github.com/refraction-networking/utls/pull/356, works for both TLSv1.3 and TLSv1.2.

Please squash.