### PR TITLE
feat: add firefox 148 spec

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -602,7 +602,7 @@ var (
 	HelloRandomizedNoALPN = ClientHelloID{helloRandomizedNoALPN, helloAutoVers, nil, nil}
 
 	// The rest will will parrot given browser.
-	HelloFirefox_Auto = HelloFirefox_120
+	HelloFirefox_Auto = HelloFirefox_148
 	HelloFirefox_55   = ClientHelloID{helloFirefox, "55", nil, nil}
 	HelloFirefox_56   = ClientHelloID{helloFirefox, "56", nil, nil}
 	HelloFirefox_63   = ClientHelloID{helloFirefox, "63", nil, nil}
@@ -611,6 +611,7 @@ var (
 	HelloFirefox_102  = ClientHelloID{helloFirefox, "102", nil, nil}
 	HelloFirefox_105  = ClientHelloID{helloFirefox, "105", nil, nil}
 	HelloFirefox_120  = ClientHelloID{helloFirefox, "120", nil, nil}
+	HelloFirefox_148  = ClientHelloID{helloFirefox, "148", nil, nil}
 
 	HelloChrome_Auto        = HelloChrome_133
 	HelloChrome_58          = ClientHelloID{helloChrome, "58", nil, nil}

--- a/u_parrots_test.go
+++ b/u_parrots_test.go
@@ -1,0 +1,154 @@
+package tls
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+type incrementingSource struct {
+	next byte
+}
+
+func (s *incrementingSource) Read(b []byte) (int, error) {
+	for i := range b {
+		b[i] = s.next
+		s.next++
+	}
+	return len(b), nil
+}
+
+func findKeyShareExtension(t *testing.T, exts []TLSExtension) *KeyShareExtension {
+	t.Helper()
+
+	for _, ext := range exts {
+		if keyShareExt, ok := ext.(*KeyShareExtension); ok {
+			return keyShareExt
+		}
+	}
+
+	t.Fatal("key_share extension not found")
+	return nil
+}
+
+func findKeyShareData(t *testing.T, keyShareExt *KeyShareExtension, group CurveID) []byte {
+	t.Helper()
+
+	for _, keyShare := range keyShareExt.KeyShares {
+		if keyShare.Group == group {
+			return keyShare.Data
+		}
+	}
+
+	t.Fatalf("key_share for group %v not found", group)
+	return nil
+}
+
+func newTestUConnWithIncrementingRand() *UConn {
+	return UClient(&net.TCPConn{}, &Config{
+		ServerName: "example.com",
+		Rand:       &incrementingSource{},
+	}, HelloCustom)
+}
+
+func fingerprintsWithHybridClassicalKeyShareReuse() []ClientHelloID {
+	return []ClientHelloID{
+		HelloFirefox_148,
+	}
+}
+
+func TestParrotFingerprintsReuseHybridClassicalKeyShare(t *testing.T) {
+	for _, helloID := range fingerprintsWithHybridClassicalKeyShareReuse() {
+		t.Run(helloID.Str(), func(t *testing.T) {
+			spec, err := UTLSIdToSpec(helloID)
+			if err != nil {
+				t.Fatalf("unexpected error creating %s spec: %v", helloID.Str(), err)
+			}
+
+			uconn := newTestUConnWithIncrementingRand()
+			if err := uconn.ApplyPreset(&spec); err != nil {
+				t.Fatalf("unexpected error applying %s spec: %v", helloID.Str(), err)
+			}
+
+			keyShareExt := findKeyShareExtension(t, uconn.Extensions)
+			hybridData := findKeyShareData(t, keyShareExt, X25519MLKEM768)
+			classicalData := findKeyShareData(t, keyShareExt, X25519)
+
+			if len(hybridData) < x25519PublicKeySize {
+				t.Fatalf("hybrid keyshare is too short: got %d bytes", len(hybridData))
+			}
+			hybridClassicalPart := hybridData[len(hybridData)-x25519PublicKeySize:]
+			if !bytes.Equal(hybridClassicalPart, classicalData) {
+				t.Fatalf("expected %s to reuse classical keyshare: hybrid classical part != X25519 keyshare", helloID.Str())
+			}
+
+			keys := uconn.HandshakeState.State13.KeyShareKeys
+			if keys == nil || keys.MlkemEcdhe == nil || keys.Ecdhe == nil {
+				t.Fatal("expected both hybrid and classical ECDHE private keys to be set")
+			}
+			if keys.MlkemEcdhe != keys.Ecdhe {
+				t.Fatalf("expected %s hybrid/classical keyshares to reuse the same ECDHE private key", helloID.Str())
+			}
+		})
+	}
+}
+
+func TestHybridClassicalKeySharesAreIndependentByDefault(t *testing.T) {
+	spec := ClientHelloSpec{
+		TLSVersMin: VersionTLS12,
+		TLSVersMax: VersionTLS13,
+		CipherSuites: []uint16{
+			TLS_AES_128_GCM_SHA256,
+		},
+		CompressionMethods: []uint8{compressionNone},
+		Extensions: []TLSExtension{
+			&SupportedCurvesExtension{
+				Curves: []CurveID{
+					X25519MLKEM768,
+					X25519,
+				},
+			},
+			&KeyShareExtension{
+				KeyShares: []KeyShare{
+					{
+						Group: X25519MLKEM768,
+					},
+					{
+						Group: X25519,
+					},
+				},
+			},
+			&SupportedVersionsExtension{
+				Versions: []uint16{
+					VersionTLS13,
+					VersionTLS12,
+				},
+			},
+		},
+	}
+
+	uconn := newTestUConnWithIncrementingRand()
+	if err := uconn.ApplyPreset(&spec); err != nil {
+		t.Fatalf("unexpected error applying independent keyshare spec: %v", err)
+	}
+
+	keyShareExt := findKeyShareExtension(t, uconn.Extensions)
+	hybridData := findKeyShareData(t, keyShareExt, X25519MLKEM768)
+	classicalData := findKeyShareData(t, keyShareExt, X25519)
+
+	if len(hybridData) < x25519PublicKeySize {
+		t.Fatalf("hybrid keyshare is too short: got %d bytes", len(hybridData))
+	}
+	hybridClassicalPart := hybridData[len(hybridData)-x25519PublicKeySize:]
+	if bytes.Equal(hybridClassicalPart, classicalData) {
+		t.Fatalf("expected independent keyshares by default: hybrid classical part == X25519 keyshare")
+	}
+
+	keys := uconn.HandshakeState.State13.KeyShareKeys
+	if keys == nil || keys.MlkemEcdhe == nil || keys.Ecdhe == nil {
+		t.Fatal("expected both hybrid and classical ECDHE private keys to be set")
+	}
+	if keys.MlkemEcdhe == keys.Ecdhe {
+		t.Fatal("expected independent keyshares by default: hybrid/classical ECDHE private keys should differ")
+	}
+}

--- a/u_public.go
+++ b/u_public.go
@@ -643,16 +643,22 @@ func (fh *finishedHash) getPublicObj() FinishedHash {
 
 // TLS 1.3 Key Share. See RFC 8446, Section 4.2.8.
 type KeyShare struct {
-	Group                    CurveID `json:"group"`
-	Data                     []byte  `json:"key_exchange,omitempty"` // optional
-	hybridClassicalReuseWith CurveID
+	Group CurveID `json:"group"`
+	Data  []byte  `json:"key_exchange,omitempty"` // optional
 }
+
+const (
+	// Internal marker bytes used by ReuseHybridAndClassicalKeyShares.
+	// ApplyPreset consumes these and generates real keyshare bytes.
+	keyShareHybridReuseMarker    byte = 0xf1
+	keyShareClassicalReuseMarker byte = 0xf2
+)
 
 // ReuseHybridAndClassicalKeyShares marks a hybrid/classical keyshare pair so
 // ApplyPreset reuses the same classical key material for both entries.
 func ReuseHybridAndClassicalKeyShares(hybrid, classical KeyShare) []KeyShare {
-	hybrid.hybridClassicalReuseWith = classical.Group
-	classical.hybridClassicalReuseWith = hybrid.Group
+	hybrid.Data = []byte{keyShareHybridReuseMarker}
+	classical.Data = []byte{keyShareClassicalReuseMarker}
 	return []KeyShare{hybrid, classical}
 }
 

--- a/u_public.go
+++ b/u_public.go
@@ -643,8 +643,17 @@ func (fh *finishedHash) getPublicObj() FinishedHash {
 
 // TLS 1.3 Key Share. See RFC 8446, Section 4.2.8.
 type KeyShare struct {
-	Group CurveID `json:"group"`
-	Data  []byte  `json:"key_exchange,omitempty"` // optional
+	Group                    CurveID `json:"group"`
+	Data                     []byte  `json:"key_exchange,omitempty"` // optional
+	hybridClassicalReuseWith CurveID
+}
+
+// ReuseHybridAndClassicalKeyShares marks a hybrid/classical keyshare pair so
+// ApplyPreset reuses the same classical key material for both entries.
+func ReuseHybridAndClassicalKeyShares(hybrid, classical KeyShare) []KeyShare {
+	hybrid.hybridClassicalReuseWith = classical.Group
+	classical.hybridClassicalReuseWith = hybrid.Group
+	return []KeyShare{hybrid, classical}
 }
 
 func (ks KeyShare) ToPrivate() keyShare {


### PR DESCRIPTION
For browsers that sends pq hybrid and classical keyshare pairs, it may or may not choose to reuse the classical part between them. Add a helper to be used when crafting the spec to signify that the reuse should happen, and implement the reuse when generating keyshares. Existing specs will still generate keys independently.

Add Firefox 148 spec that uses this reuse.