### PR TITLE
feat: Config.NextProtos for inner CH when ECH is enabled

### DIFF
--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -611,8 +611,11 @@ type ALPNExtension struct {
 }
 
 func (e *ALPNExtension) writeToUConn(uc *UConn) error {
-	uc.config.NextProtos = e.AlpnProtocols
-	uc.HandshakeState.Hello.AlpnProtocols = e.AlpnProtocols
+	// If ech is enabled, the uc.config.NextProtos should not be changed.
+	if uc.config.EncryptedClientHelloConfigList == nil {
+		uc.config.NextProtos = e.AlpnProtocols
+		uc.HandshakeState.Hello.AlpnProtocols = e.AlpnProtocols
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #355 by letting `Config.NextProtos` determine the ALPN list in the inner ClientHello when ECH is enabled, while the outer ClientHello continues to use the preset ALPN from `ClientHelloSpec.Extensions`.

A unit test for this ALPN-ECH will be submitted in another commit.