### PR TITLE
fix: darwin arm64 always has AESGCMHardwareSupport

### DIFF
--- a/cipher_suites.go
+++ b/cipher_suites.go
@@ -368,7 +368,7 @@ var tdesCiphers = map[uint16]bool{
 var (
 	// Keep in sync with crypto/internal/fips140/aes/gcm.supportsAESGCM.
 	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ && cpu.X86.HasSSE41 && cpu.X86.HasSSSE3
-	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	hasGCMAsmARM64 = (cpu.ARM64.HasAES && cpu.ARM64.HasPMULL) || (runtime.GOOS == "darwin" && runtime.GOARCH == "arm64")
 	hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCTR && cpu.S390X.HasGHASH
 	hasGCMAsmPPC64 = runtime.GOARCH == "ppc64" || runtime.GOARCH == "ppc64le"
 


### PR DESCRIPTION
While merging the relevant commits for go1.25, we discovered a minor issue: the value of `hasAESGCMHardwareSupport` was always false on ARM64 Macs.

Comparing the values ​​of `cpu.ARM64.HasAES` and `cpu.ARM64.HasPMULL` in `internal/cpu` and `x/sys/cpu` confirmed inconsistencies.

Given that `hasAESGCMHardwareSupport` is heavily used in TLS, maintaining a consistent value with the standard library ensures synchronization with the standard library's behavior.

From the comments in the standard library: https://github.com/golang/go/blob/go1.25.0/src/internal/cpu/cpu_arm64_darwin.go#L26-L30

For ARM64 Darwin platforms (excluding iOS), AES GCM hardware acceleration is always available.