### PR TITLE
fix: use AES in GREASE ECH for Chrome fingerprint

### DIFF
--- a/u_ech.go
+++ b/u_ech.go
@@ -300,10 +300,6 @@ func BoringGREASEECH() *GREASEEncryptedClientHelloExtension {
 				KdfId:  dicttls.HKDF_SHA256,
 				AeadId: dicttls.AEAD_AES_128_GCM,
 			},
-			{
-				KdfId:  dicttls.HKDF_SHA256,
-				AeadId: dicttls.AEAD_CHACHA20_POLY1305,
-			},
 		},
 		CandidatePayloadLens: []uint16{128, 160, 192, 224}, // +16: 144, 176, 208, 240
 	}


### PR DESCRIPTION
There is a fingerprint mismatch with Chrome when using GREASE ECH, having to do with ciphersuite selection. When Chrome selects the preferred ciphersuite in the outer ClientHello and the ciphersuite for ECH, it does so consistently based on hardware support. That means, for example, if it prefers AES for the outer ciphersuite, it would also use AES for ECH. The Chrome parrot in utls hardcodes AES preference for outer ciphersuites but selects the ECH ciphersuite randomly between AES and ChaCha20. So there is a 50% chance of selecting ChaCha20 for ECH while using AES for the outer ciphersuite, which is impossible in Chrome.

This commit makes the Chrome parrot use AES only for GREASE ECH, consistent with the currrent AES outer ciphersuite preference.

I think this is only a problem in GREASE ECH, since in real ECH Chrome selects the first valid ciphersuite when AES is preferred, which is the same in utls. So no change is done there.

Thanks to the original reporter for reporting this issue.