### PR TITLE
Expose Encrypted Client Hello in Merge branch 'oscur0-pq' into 'oscur0-ech'

### DIFF
--- a/common.go
+++ b/common.go
@@ -1041,6 +1041,7 @@ func (c *Config) Clone() *Config {
 
 		PreferSkipResumptionOnNilExtension: c.PreferSkipResumptionOnNilExtension, // [UTLS]
 		ECHConfigs:                         c.ECHConfigs,                         // [uTLS]
+		GetOscur0KeyShare:                  c.GetOscur0KeyShare,                  // [uTLS]
 	}
 }
 

--- a/common.go
+++ b/common.go
@@ -930,6 +930,10 @@ type Config struct {
 	//
 	// If GREASE ECH extension is present, this field will be ignored.
 	ECHConfigs []ECHConfig // [uTLS]
+
+	// GetOscur0KeyShare gets the first keyshare, terminate the connection if
+	// non-nil err is returned. For use with Oscur0 only.
+	GetOscur0KeyShare func(*KeyShare) error // [uTLS]
 }
 
 // EncryptedClientHelloKey holds a private key that is associated

--- a/common.go
+++ b/common.go
@@ -476,6 +476,8 @@ type ClientHelloInfo struct {
 	// for use with SupportsCertificate.
 	config *Config
 
+	EncryptedClientHello []byte // [uTLS] raw outer ECH payload
+
 	// ctx is the context of the handshake that is in progress.
 	ctx context.Context
 }

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -994,16 +994,17 @@ func clientHelloInfo(ctx context.Context, c *Conn, clientHello *clientHelloMsg) 
 	}
 
 	return &ClientHelloInfo{
-		CipherSuites:      clientHello.cipherSuites,
-		ServerName:        clientHello.serverName,
-		SupportedCurves:   clientHello.supportedCurves,
-		SupportedPoints:   clientHello.supportedPoints,
-		SignatureSchemes:  clientHello.supportedSignatureAlgorithms,
-		SupportedProtos:   clientHello.alpnProtocols,
-		SupportedVersions: supportedVersions,
-		Extensions:        clientHello.extensions,
-		Conn:              c.conn,
-		config:            c.config,
-		ctx:               ctx,
+		CipherSuites:         clientHello.cipherSuites,
+		ServerName:           clientHello.serverName,
+		SupportedCurves:      clientHello.supportedCurves,
+		SupportedPoints:      clientHello.supportedPoints,
+		SignatureSchemes:     clientHello.supportedSignatureAlgorithms,
+		SupportedProtos:      clientHello.alpnProtocols,
+		SupportedVersions:    supportedVersions,
+		Extensions:           clientHello.extensions,
+		EncryptedClientHello: append([]byte(nil), clientHello.encryptedClientHello...), // [uTLS] expose ECH
+		Conn:                 c.conn,
+		config:               c.config,
+		ctx:                  ctx,
 	}
 }

--- a/handshake_server_tls13.go
+++ b/handshake_server_tls13.go
@@ -231,6 +231,11 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 
 	var clientKeyShare *keyShare
 	for _, ks := range hs.clientHello.keyShares {
+		if ks.group == X25519MLKEM768 && hs.c.config.GetOscur0KeyShare != nil {
+			if err := hs.c.config.GetOscur0KeyShare(&KeyShare{Group: ks.group, Data: ks.data}); err != nil {
+				return err
+			}
+		}
 		if ks.group == selectedGroup {
 			clientKeyShare = &ks
 			break
@@ -254,11 +259,6 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 			return errors.New("tls: invalid X25519MLKEM768 client key share")
 		}
 		ecdhData = ecdhData[mlkem.EncapsulationKeySize768:]
-		if hs.c.config.GetOscur0KeyShare != nil {
-			if err := hs.c.config.GetOscur0KeyShare(&KeyShare{Group: clientKeyShare.group, Data: clientKeyShare.data}); err != nil {
-				return err
-			}
-		}
 	}
 	if _, ok := curveForCurveID(ecdhGroup); !ok {
 		c.sendAlert(alertInternalError)

--- a/handshake_server_tls13.go
+++ b/handshake_server_tls13.go
@@ -254,6 +254,11 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 			return errors.New("tls: invalid X25519MLKEM768 client key share")
 		}
 		ecdhData = ecdhData[mlkem.EncapsulationKeySize768:]
+		if hs.c.config.GetOscur0KeyShare != nil {
+			if err := hs.c.config.GetOscur0KeyShare(&KeyShare{Group: clientKeyShare.group, Data: clientKeyShare.data}); err != nil {
+				return err
+			}
+		}
 	}
 	if _, ok := curveForCurveID(ecdhGroup); !ok {
 		c.sendAlert(alertInternalError)


### PR DESCRIPTION
This PR adds server-side access to the raw `encrypted_client_hello` (ECH, `0xfe0d`) extension payload by exposing it on `*tls.ClientHelloInfo`. Moreover, this PR merged with the oscur-pq branch, solving conflicts.