### PR TITLE
fix: add missing padding extension for chrome 120

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -731,6 +731,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				&ApplicationSettingsExtension{SupportedProtocols: []string{"h2"}},
 				BoringGREASEECH(),
 				&UtlsGREASEExtension{},
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
 			}),
 		}, nil
 	// Chrome w/ Post-Quantum Key Agreement and ECH


### PR DESCRIPTION
Chrome removed this extension when sending pq keyshares but this was incorrectly removed in utls for the non-pq variant of Chrome 120 fingerprint. Only this fingerprint is effected since newer fingerprints have pq keyshares by default and older fingerprints have this extension.

Thanks to telegram @acgdaily for reporting this issue.