### PR TITLE
Hide ALPN in ECH

### DIFF
--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -242,10 +242,11 @@ func (m *clientHelloMsg) marshalMsgReorderOuterExts(echInner bool, outerExts []u
 		}
 	}
 	if len(m.alpnProtocols) > 0 {
-		// RFC 7301, Section 3.1
-		if echInner {
+		// ALPN extension copy is skipped because in ECH inner, the ALPN might be different
+		if echInner && false {
 			echOuterExts = append(echOuterExts, extensionALPN)
 		} else {
+			// RFC 7301, Section 3.1
 			exts.AddUint16(extensionALPN)
 			exts.AddUint16LengthPrefixed(func(exts *cryptobyte.Builder) {
 				exts.AddUint16LengthPrefixed(func(exts *cryptobyte.Builder) {

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -611,8 +611,12 @@ type ALPNExtension struct {
 }
 
 func (e *ALPNExtension) writeToUConn(uc *UConn) error {
-	uc.config.NextProtos = e.AlpnProtocols
-	uc.HandshakeState.Hello.AlpnProtocols = e.AlpnProtocols
+	// Do not overwrite NextProtos in config if Encrypted Client Hello is used.
+	// Config ALPN will be written to inner Hello
+	if uc.config.EncryptedClientHelloConfigList == nil {
+		uc.config.NextProtos = e.AlpnProtocols
+		uc.HandshakeState.Hello.AlpnProtocols = e.AlpnProtocols
+	}
 	return nil
 }
 


### PR DESCRIPTION
Close #355

Tested and works perfectly. wss alpn `http/1.1` is hidden.
<img width="589" height="208" alt="image" src="https://github.com/user-attachments/assets/88042cf3-ebcf-4e5b-b04c-e1e822d4332a" />

When I finished the work I found #365 but it didn't write ALPN correctly when building the inner hello