### PR TITLE
Fix race condition in loadSession with shared session cache

### DIFF
--- a/handshake_client.go
+++ b/handshake_client.go
@@ -435,6 +435,11 @@ func (c *Conn) loadSession(hello *clientHelloMsg) (
 	}
 	session = cs.session
 
+	// Shallow copy the session to prevent a race condition where
+	// SessionTicketExtension.InitializeByUtls mutates the shared cache entry.
+	sessionCopy := *session
+	session = &sessionCopy
+
 	// Check that version used for the previous session is still valid.
 	versOk := false
 	for _, v := range hello.supportedVersions {


### PR DESCRIPTION
When multiple goroutines share a ClientSessionCache, loadSession() returns a *SessionState pointer that is shared across connections. Subsequent code (e.g. SessionTicketExtension.InitializeByUtls) mutates this session object, causing a data race. Fix by making a shallow copy of the SessionState immediately after retrieving it from the cache.