### PR TITLE
fix: add missing session_ticket and psk_key_exchange_modes to HelloFirefox_148

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1514,6 +1514,7 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 						0x0, // uncompressed
 					},
 				},
+				&SessionTicketExtension{},
 				&ALPNExtension{
 					AlpnProtocols: []string{
 						"h2",
@@ -1566,6 +1567,9 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 						PKCS1WithSHA1,
 					},
 				},
+				&PSKKeyExchangeModesExtension{[]uint8{
+					PskModeDHE,
+				}},
 				&FakeRecordSizeLimitExtension{
 					Limit: 0x4001,
 				},


### PR DESCRIPTION
Fixes #390

## Summary

Add `SessionTicketExtension` (ext 35) and `PSKKeyExchangeModesExtension` (ext 45) to the `HelloFirefox_148` spec, matching their placement in real Firefox and all previous Firefox parrots.

## Changes

- Insert `&SessionTicketExtension{}` after `SupportedPointsExtension`
- Insert `&PSKKeyExchangeModesExtension{[]uint8{PskModeDHE}}` after `SignatureAlgorithmsExtension`

## Verification

Captured ja3n fingerprint before and after fix via browserleaks.com reflector:

| | ja3n extensions |
|---|---|
| Real Firefox 149 | `0-5-10-11-13-16-18-23-27-28-34-35-43-45-51-65037-65281` |
| utls (before) | `0-5-10-11-13-16-18-23-27-28-34-43-51-65037-65281` |
| utls (after) | `0-5-10-11-13-16-18-23-27-28-34-35-43-45-51-65037-65281` |
