### PR TITLE
feat: add HelloAndroid_16_OkHttp ClientHello fingerprint

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -653,6 +653,7 @@ var (
 	HelloIOS_14   = ClientHelloID{helloIOS, "14", nil, nil}
 
 	HelloAndroid_11_OkHttp = ClientHelloID{helloAndroid, "11", nil, nil}
+    HelloAndroid_16_OkHttp = ClientHelloID{helloAndroid, "16", nil, nil}
 
 	HelloEdge_Auto = HelloEdge_85 // HelloEdge_106 seems to be incompatible with this library
 	HelloEdge_85   = ClientHelloID{helloEdge, "85", nil, nil}

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -1918,6 +1918,69 @@ func utlsIdToSpec(id ClientHelloID) (ClientHelloSpec, error) {
 				}},
 			},
 		}, nil
+    case HelloAndroid_16_OkHttp:
+		return ClientHelloSpec{
+			TLSVersMin: VersionTLS12,
+			TLSVersMax: VersionTLS13,
+			CipherSuites: []uint16{
+				TLS_AES_128_GCM_SHA256,
+				TLS_AES_256_GCM_SHA384,
+				TLS_CHACHA20_POLY1305_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				0xcca9,
+				0xcca8,
+				TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				TLS_RSA_WITH_AES_128_GCM_SHA256,
+				TLS_RSA_WITH_AES_256_GCM_SHA384,
+				TLS_RSA_WITH_AES_128_CBC_SHA,
+				TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+			CompressionMethods: []byte{
+				0x00,
+			},
+			Extensions: []TLSExtension{
+				&SNIExtension{},
+				&ExtendedMasterSecretExtension{},
+				&RenegotiationInfoExtension{Renegotiation: RenegotiateOnceAsClient},
+				&SupportedCurvesExtension{Curves: []CurveID{
+					X25519,
+					CurveP256,
+					CurveP384,
+				}},
+				&SupportedPointsExtension{SupportedPoints: []byte{
+					0x00,
+				}},
+				&SessionTicketExtension{},
+				&ALPNExtension{AlpnProtocols: []string{"h2", "http/1.1"}},
+				&StatusRequestExtension{},
+				&SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []SignatureScheme{
+					ECDSAWithP256AndSHA256,
+					PSSWithSHA256,
+					PKCS1WithSHA256,
+					ECDSAWithP384AndSHA384,
+					PSSWithSHA384,
+					PKCS1WithSHA384,
+					PSSWithSHA512,
+					PKCS1WithSHA512,
+					PKCS1WithSHA1,
+				}},
+				&KeyShareExtension{KeyShares: []KeyShare{
+					{Group: X25519},
+				}},
+				&PSKKeyExchangeModesExtension{Modes: []uint8{
+					PskModeDHE,
+				}},
+				&SupportedVersionsExtension{Versions: []uint16{
+					VersionTLS13,
+					VersionTLS12,
+				}},
+				&UtlsPaddingExtension{GetPaddingLen: BoringPaddingStyle},
+			},
+		}, nil
 	case HelloEdge_85:
 		return ClientHelloSpec{
 			CipherSuites: []uint16{


### PR DESCRIPTION
This PR introduces the HelloAndroid_16_OkHttp fingerprint to accurately mimic the ClientHello of Android 16 using OkHttp 5.3.0.

**Key Changes**:

- Added HelloAndroid_16_OkHttp constant and its corresponding ClientHelloSpec mapping.
- Matched the exact CipherSuites and Extensions lists (and their strict order) based on real-world packet captures.
- Ensured full TLS 1.3 compatibility by correctly implementing SupportedVersions, KeyShare, and PSKKeyExchangeModes extensions.
- Omitted GREASE values, ALPS, and certificate compression extensions to align strictly with vanilla OkHttp behavior.