### PR TITLE
fix: inversion of IsSet() in ClientHelloID

### DIFF
--- a/u_common.go
+++ b/u_common.go
@@ -158,7 +158,7 @@ func (p *ClientHelloID) Str() string {
 }
 
 func (p *ClientHelloID) IsSet() bool {
-	return (p.Client == "") && (p.Version == "")
+	return p.Client != "" || p.Version != ""
 }
 
 const (


### PR DESCRIPTION
Obviously, this function is not working as designed. This PR fixes that.