### PR TITLE
Preserve certificateMsgTLS13 original bytes for the TLS 1.3 transcript

### DIFF
--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -1499,6 +1499,7 @@ func (m *certificateMsg) unmarshal(data []byte) bool {
 }
 
 type certificateMsgTLS13 struct {
+	original     []byte // [uTLS]
 	certificate  Certificate
 	ocspStapling bool
 	scts         bool
@@ -1561,7 +1562,7 @@ func marshalCertificate(b *cryptobyte.Builder, certificate Certificate) {
 }
 
 func (m *certificateMsgTLS13) unmarshal(data []byte) bool {
-	*m = certificateMsgTLS13{}
+	*m = certificateMsgTLS13{original: data} // [uTLS]
 	s := cryptobyte.String(data)
 
 	var context cryptobyte.String
@@ -1577,6 +1578,22 @@ func (m *certificateMsgTLS13) unmarshal(data []byte) bool {
 
 	return true
 }
+
+// [UTLS SECTION BEGINS]
+// originalBytes lets transcriptMsg hash this Certificate message exactly as it
+// was received, instead of a re-marshal via marshalCertificate(). The re-marshal
+// is not guaranteed to be byte-identical to the peer's encoding (only leaf
+// OCSP/SCT are re-emitted, in a fixed order; other per-certificate extensions
+// and non-canonical length encodings are lost), which diverges the TLS 1.3
+// handshake transcript and causes CertificateVerify to fail with
+// "crypto/rsa: verification error". clientHelloMsg, serverHelloMsg and
+// certificateRequestMsgTLS13 already preserve their original bytes for the same
+// reason.
+func (m *certificateMsgTLS13) originalBytes() []byte {
+	return m.original
+}
+
+// [UTLS SECTION ENDS]
 
 func unmarshalCertificate(s *cryptobyte.String, certificate *Certificate) bool {
 	var certList cryptobyte.String

--- a/handshake_messages_test.go
+++ b/handshake_messages_test.go
@@ -100,6 +100,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 					t.original = nil
 				case *certificateRequestMsgTLS13: // [UTLS]
 					t.original = nil // [UTLS]
+				case *certificateMsgTLS13: // [UTLS]
+					t.original = nil // [UTLS]
 				}
 
 				if !reflect.DeepEqual(m1, m) {

--- a/u_certificate_originalbytes_test.go
+++ b/u_certificate_originalbytes_test.go
@@ -1,0 +1,82 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// buildTLS13CertificateWithLeafExtension builds a valid TLS 1.3 Certificate
+// handshake message whose leaf certificate carries an extension that
+// marshalCertificate does not re-emit (it only re-emits OCSP and SCT).
+// Re-marshaling therefore drops the extension, so a transcript computed from
+// the re-marshal diverges from the peer's — which makes CertificateVerify fail
+// with "crypto/rsa: verification error".
+func buildTLS13CertificateWithLeafExtension() []byte {
+	var b cryptobyte.Builder
+	b.AddUint8(typeCertificate)
+	b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddUint8(0) // empty certificate_request_context
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			// single leaf certificate
+			b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+				b.AddBytes([]byte("dummy-leaf-der"))
+			})
+			// leaf extensions: one extension that unmarshal ignores and
+			// marshalCertificate never re-emits.
+			b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+				b.AddUint16(0x1234) // unknown extension type
+				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+					b.AddBytes([]byte("ext-payload"))
+				})
+			})
+		})
+	})
+	out, err := b.Bytes()
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// TestCertificateMsgTLS13PreservesOriginalBytes ensures certificateMsgTLS13
+// feeds transcriptMsg the exact bytes it was unmarshaled from, not a
+// (potentially lossy) re-marshal.
+func TestCertificateMsgTLS13PreservesOriginalBytes(t *testing.T) {
+	wire := buildTLS13CertificateWithLeafExtension()
+
+	var m certificateMsgTLS13
+	if !m.unmarshal(wire) {
+		t.Fatal("unmarshal failed")
+	}
+
+	wm, ok := handshakeMessage(&m).(handshakeMessageWithOriginalBytes)
+	if !ok {
+		t.Fatal("certificateMsgTLS13 does not implement handshakeMessageWithOriginalBytes")
+	}
+	if !bytes.Equal(wm.originalBytes(), wire) {
+		t.Fatalf("originalBytes() != wire\n orig=%x\n wire=%x", wm.originalBytes(), wire)
+	}
+
+	// Guard: the re-marshal must actually diverge from the wire, otherwise the
+	// test is no longer exercising the bug.
+	remarshaled, err := m.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Equal(remarshaled, wire) {
+		t.Fatal("re-marshal unexpectedly equals wire; test no longer exercises the divergence")
+	}
+
+	// transcriptMsg must hash the original wire bytes, not the re-marshal.
+	h := sha256.New()
+	if err := transcriptMsg(&m, h); err != nil {
+		t.Fatalf("transcriptMsg: %v", err)
+	}
+	want := sha256.Sum256(wire)
+	if got := h.Sum(nil); !bytes.Equal(got, want[:]) {
+		t.Fatal("transcriptMsg hashed the re-marshal instead of the original wire bytes")
+	}
+}


### PR DESCRIPTION
## Problem

TLS 1.3 handshakes can fail at `CertificateVerify` with:

```
tls: invalid signature by the server certificate: crypto/rsa: verification error
```

against real production HTTPS endpoints — even though the certificate chain validates and the same server works with `crypto/tls` and with a Chrome fingerprint.

## Root cause

`certificateMsgTLS13` does not implement `handshakeMessageWithOriginalBytes`. When uTLS reads the server Certificate with `readHandshake(nil)` (to support RFC 8879 cert compression) and then hashes it into the transcript via `transcriptMsg`, the fallback path **re-marshals** the parsed message with `marshalCertificate()`:

```go
func transcriptMsg(msg handshakeMessage, h transcriptHash) error {
    if msgWithOrig, ok := msg.(handshakeMessageWithOriginalBytes); ok {
        if orig := msgWithOrig.originalBytes(); orig != nil {
            h.Write(orig)              // faithful
            return nil
        }
    }
    data, err := msg.marshal()         // <- re-marshal, may diverge
    ...
}
```

`marshalCertificate()` is **not guaranteed to reproduce the peer's byte encoding**: it only re-emits OCSP/SCT (in a fixed order) for the leaf, and drops any other per-certificate extension; non-canonical length encodings are also lost. When the server's Certificate message doesn't round-trip exactly, the client's transcript diverges from the server's, so the `CertificateVerify` signature — which is correct — fails to verify against the client's (wrong) transcript hash.

This only affects the **uncompressed**-certificate path; compressed certificates already transcript their raw `CompressedCertificate` bytes. It's deterministic and reproducible against production servers whose leaf Certificate carries an extension beyond OCSP/SCT.

## Fix

`clientHelloMsg`, `serverHelloMsg` and `certificateRequestMsgTLS13` already cache their original wire bytes for exactly this reason (the June-2025 `originalBytes` work). `certificateMsgTLS13` was the one TLS 1.3 transcript message left out. This PR:

- adds `original []byte` to `certificateMsgTLS13`, captures it in `unmarshal`, and returns it from `originalBytes()`;
- nils it in `TestMarshalUnmarshal` alongside the sibling messages;
- adds a regression test that builds a Certificate whose leaf carries an extension `marshalCertificate` drops, and asserts `transcriptMsg` hashes the original wire bytes rather than the divergent re-marshal.

`go test ./...` passes; the new test fails without the `handshake_messages.go` change.