### PR TITLE
Draw the GREASE signature algorithm from the per-connection seed

### DIFF
--- a/u_grease_sigalg_test.go
+++ b/u_grease_sigalg_test.go
@@ -1,0 +1,118 @@
+package tls
+
+import (
+	"net"
+	"testing"
+)
+
+// sigAlgGREASESpec makes a small spec. Its signature_algorithms extension starts with
+// the GREASE placeholder, the same way the Chrome list starts with a GREASE value.
+// Each connection needs a new spec, because ApplyPreset writes over the placeholder in
+// the extension.
+func sigAlgGREASESpec() ClientHelloSpec {
+	return ClientHelloSpec{
+		TLSVersMin:         VersionTLS12,
+		TLSVersMax:         VersionTLS13,
+		CipherSuites:       []uint16{TLS_AES_128_GCM_SHA256},
+		CompressionMethods: []uint8{compressionNone},
+		Extensions: []TLSExtension{
+			&SignatureAlgorithmsExtension{
+				SupportedSignatureAlgorithms: []SignatureScheme{
+					SignatureScheme(GREASE_PLACEHOLDER),
+					ECDSAWithP256AndSHA256,
+					PSSWithSHA256,
+					PKCS1WithSHA256,
+				},
+			},
+		},
+	}
+}
+
+// applySigAlgGREASESpec applies a new spec to a new connection. It returns the
+// signature algorithms that ApplyPreset wrote.
+func applySigAlgGREASESpec(t *testing.T) []SignatureScheme {
+	t.Helper()
+
+	spec := sigAlgGREASESpec()
+	uconn := UClient(&net.TCPConn{}, &Config{ServerName: "example.com"}, HelloCustom)
+	if err := uconn.ApplyPreset(&spec); err != nil {
+		t.Fatalf("unexpected error applying signature algorithms spec: %v", err)
+	}
+
+	for _, ext := range uconn.Extensions {
+		if sigAlgExt, ok := ext.(*SignatureAlgorithmsExtension); ok {
+			return sigAlgExt.SupportedSignatureAlgorithms
+		}
+	}
+
+	t.Fatal("signature_algorithms extension not found")
+	return nil
+}
+
+// TestSignatureAlgorithmsGREASESubstitution checks three properties of the
+// substitution:
+//
+//  1. ApplyPreset replaces the GREASE placeholder in signature_algorithms with a real
+//     GREASE value.
+//  2. ApplyPreset draws that value again for each connection.
+//  3. ApplyPreset keeps the other signature algorithms unchanged.
+//
+// Without the substitution, the literal placeholder 0x0a0a goes on the wire on every
+// connection. That constant is a reliable "this is not Chrome" signal.
+func TestSignatureAlgorithmsGREASESubstitution(t *testing.T) {
+	const connections = 64
+
+	values := make(map[SignatureScheme]bool)
+	for i := 0; i < connections; i++ {
+		sigAlgs := applySigAlgGREASESpec(t)
+		if len(sigAlgs) != 4 {
+			t.Fatalf("signature_algorithms holds %d entries, want 4", len(sigAlgs))
+		}
+
+		if !isGREASEUint16(uint16(sigAlgs[0])) {
+			t.Fatalf("substituted signature algorithm = %#04x, which is not a 0x?a?a value", uint16(sigAlgs[0]))
+		}
+
+		if sigAlgs[1] != ECDSAWithP256AndSHA256 || sigAlgs[2] != PSSWithSHA256 || sigAlgs[3] != PKCS1WithSHA256 {
+			t.Fatalf("non-GREASE signature algorithms were rewritten: got %#04x, %#04x, %#04x",
+				uint16(sigAlgs[1]), uint16(sigAlgs[2]), uint16(sigAlgs[3]))
+		}
+
+		values[sigAlgs[0]] = true
+	}
+
+	// There are 16 GREASE values. A run that returns the placeholder, or any other
+	// constant, therefore gives one distinct value. This test asks for more than one
+	// distinct value only. 64 draws from 16 values usually give a much larger count.
+	// A larger minimum would fail on an unlucky run.
+	if len(values) < 2 {
+		t.Errorf("%d connections produced only %d distinct GREASE signature algorithms", connections, len(values))
+	}
+	if values[SignatureScheme(GREASE_PLACEHOLDER)] && len(values) == 1 {
+		t.Error("the GREASE placeholder was sent unchanged")
+	}
+}
+
+// TestSignatureAlgorithmsGREASEMatchesSeed checks that the substituted value comes
+// from the per-connection GREASE seed, and not from a separate random draw. BoringSSL
+// derives every GREASE value in one ClientHello from that one seed. This test also
+// checks that the value comes from the seed index reserved for signature algorithms.
+func TestSignatureAlgorithmsGREASEMatchesSeed(t *testing.T) {
+	spec := sigAlgGREASESpec()
+	uconn := UClient(&net.TCPConn{}, &Config{ServerName: "example.com"}, HelloCustom)
+	if err := uconn.ApplyPreset(&spec); err != nil {
+		t.Fatalf("unexpected error applying signature algorithms spec: %v", err)
+	}
+
+	var got SignatureScheme
+	for _, ext := range uconn.Extensions {
+		if sigAlgExt, ok := ext.(*SignatureAlgorithmsExtension); ok {
+			got = sigAlgExt.SupportedSignatureAlgorithms[0]
+		}
+	}
+
+	want := SignatureScheme(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_signature_algorithm))
+	if got != want {
+		t.Errorf("substituted signature algorithm = %#04x, want the seeded value %#04x", uint16(got), uint16(want))
+	}
+}

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -3211,6 +3211,12 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 					ext.Versions[i] = GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_version)
 				}
 			}
+		case *SignatureAlgorithmsExtension:
+			for i := range ext.SupportedSignatureAlgorithms {
+				if isGREASEUint16(uint16(ext.SupportedSignatureAlgorithms[i])) { // just in case the user set a GREASE value instead of unGREASEd
+					ext.SupportedSignatureAlgorithms[i] = SignatureScheme(GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_signature_algorithm))
+				}
+			}
 		case *NPNExtension:
 			haveNPN = true
 		}

--- a/u_tls_extensions.go
+++ b/u_tls_extensions.go
@@ -965,6 +965,7 @@ const (
 	ssl_grease_extension1
 	ssl_grease_extension2
 	ssl_grease_version
+	ssl_grease_signature_algorithm
 	ssl_grease_ticket_extension
 	ssl_grease_last_index = ssl_grease_ticket_extension
 )


### PR DESCRIPTION
## Problem

Chrome 152 introduced a GREASE value in the `signature_algorithms` extension. Chrome sends that value first in the list and draws a new value for each connection. Chrome 151 and earlier sent no GREASE value there.

utls replaces GREASE placeholders in the cipher suites, the supported groups, the key shares, the supported versions, and the GREASE extensions. It does not replace them in `signature_algorithms`. A spec that writes `SignatureScheme(GREASE_PLACEHOLDER)` therefore sends the literal value `0x0a0a` on every connection. That constant is a reliable "this is not Chrome" signal.

## Change

- `u_tls_extensions.go`: add the seed index `ssl_grease_signature_algorithm`. It comes before `ssl_grease_ticket_extension`, so the indexes of the older positions keep their values. `ssl_grease_last_index` grows by one, and `UConn.greaseSeed` grows with it.
- `u_parrots.go`: add a `case *SignatureAlgorithmsExtension` to the reGREASE switch in `ApplyPreset`. It replaces each entry for which `isGREASEUint16` reports true with `GetBoringGREASEValue(uconn.greaseSeed, ssl_grease_signature_algorithm)`, the same way the existing curve, key share, and version cases work. The value now comes from the one per-connection seed, so the GREASE values in one ClientHello relate to each other the way BoringSSL relates them.
- `u_grease_sigalg_test.go`: new tests. They check that the placeholder becomes a `0x?a?a` value, that the other signature algorithms stay unchanged, that the value changes across 64 connections, and that the value equals the seeded value for the new index.

This change adds the mechanism only. The newest bundled Chrome profile is `HelloChrome_133`, which predates Chrome 152, so no shipped profile writes `SignatureScheme(GREASE_PLACEHOLDER)` yet. A future Chrome 152 profile, or any caller that builds its own `ClientHelloSpec`, can use it. Existing profiles send the same bytes as before.

`SignatureAlgorithmsCertExtension` gets no substitution, because BoringSSL does not GREASE it.

## Test

`go build ./...`, `go vet ./...`, and `go test ./...` pass.

The same change for the `bogdanfinn/utls` fork: bogdanfinn/utls#9.
