### PR TITLE
fix randomized X25519MLKEM768 key share consistency

### DIFF
--- a/u_parrots.go
+++ b/u_parrots.go
@@ -3339,7 +3339,8 @@ func generateRandomizedSpec(
 	points := SupportedPointsExtension{SupportedPoints: []byte{pointFormatUncompressed}}
 
 	curveIDs := []CurveID{}
-	if r.FlipWeightedCoin(id.Weights.CurveIDs_Append_X25519) && p.TLSVersMax == VersionTLS13 {
+	includeX25519MLKEM768 := r.FlipWeightedCoin(id.Weights.CurveIDs_Append_X25519) && p.TLSVersMax == VersionTLS13
+	if includeX25519MLKEM768 {
 		curveIDs = append(curveIDs, X25519MLKEM768)
 	}
 	if r.FlipWeightedCoin(id.Weights.CurveIDs_Append_X25519) || p.TLSVersMax == VersionTLS13 {
@@ -3399,9 +3400,11 @@ func generateRandomizedSpec(
 			if r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups) {
 				ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
 			}
-			if r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups) {
-				ks.KeyShares = append([]KeyShare{{Group: X25519MLKEM768}}, ks.KeyShares...)
-			}
+			// Preserve PRNG progression for existing randomized seeds.
+			_ = r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups)
+		}
+		if includeX25519MLKEM768 {
+			ks.KeyShares = append([]KeyShare{{Group: X25519MLKEM768}}, ks.KeyShares...)
 		}
 		pskExchangeModes := PSKKeyExchangeModesExtension{[]uint8{pskModeDHE}}
 		supportedVersionsExt := SupportedVersionsExtension{


### PR DESCRIPTION
## Summary

`generateRandomizedSpec` currently decides independently whether to include `X25519MLKEM768` in `supported_groups` and whether to include its initial key share.

This can produce two problematic combinations:

1. `X25519MLKEM768` is advertised without an initial key share. This is valid TLS 1.3, but allows a server to select the group through HelloRetryRequest, while the current uTLS HRR handler explicitly does not support selecting `X25519MLKEM768` through HRR.

2. `X25519MLKEM768` is included in `key_share` without being present in `supported_groups`. TLS 1.3 explicitly forbids this: every `KeyShareEntry` must correspond to a group offered in `supported_groups` ([RFC 9846 §4.3.8](https://www.rfc-editor.org/rfc/rfc9846.html#section-4.3.8)).

The existing HRR handler already assumes that if `X25519MLKEM768` is enabled, its initial key share is always sent.

## Change

Use a single randomized decision for both `supported_groups` and the initial `key_share`.

When `randomized` advertises `X25519MLKEM768`, it also includes its initial key share. Otherwise, neither is included.

The previous key-share random draw is still consumed to preserve the PRNG sequence for existing randomized seeds.

This preserves the randomized choice of whether to offer `X25519MLKEM768`, while:

- preventing invalid `supported_groups` / `key_share` combinations;
- preserving the invariant expected by the existing HRR handler;
- avoiding the unsupported `X25519MLKEM768` HRR path.

## Future HRR support

If `X25519MLKEM768` HRR support is implemented in the future, the decision to include its initial key share can be randomized again, but only when the group itself is advertised.

The result of the existing random draw can then be used instead of discarded, while the draw remains in the same key-share randomization branch.

For example:

```go
includeX25519MLKEM768KeyShare := false
if r.FlipWeightedCoin(id.Weights.FirstKeyShare_Set_CurveP256) { // legacy setting, not used by default
	ks.KeyShares[0].Group = CurveP256
} else {
	if r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups) {
		ks.KeyShares = append(ks.KeyShares, KeyShare{Group: CurveP256})
	}
	includeX25519MLKEM768KeyShare = r.FlipWeightedCoin(id.Weights.KeyShare_Append_RandomGroups)
}
if includeX25519MLKEM768 && includeX25519MLKEM768KeyShare {
	ks.KeyShares = append([]KeyShare{{Group: X25519MLKEM768}}, ks.KeyShares...)
}
```

## Related

- [refraction-networking/utls#366](https://github.com/refraction-networking/utls/issues/366)
- [XTLS/Xray-core#6714](https://github.com/XTLS/Xray-core/issues/6714)